### PR TITLE
Add support for clipping

### DIFF
--- a/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/SKCanvasExtensions.cs
+++ b/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/SKCanvasExtensions.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Linq;
+
+namespace SkiaSharp.Extended.Svg
+{
+    internal static class SKCanvasExtensions
+    {
+        public static void DrawRoundRect(this SKCanvas canvas, SKRoundedRect rect, SKPaint paint)
+        {
+            canvas.DrawRoundRect(rect.Rect, rect.RadiusX, rect.RadiusY, paint);
+        }
+
+        public static void DrawOval(this SKCanvas canvas, SKOval oval, SKPaint paint)
+        {
+            canvas.DrawOval(oval.Center.X, oval.Center.Y, oval.RadiusX, oval.RadiusY, paint);
+        }
+
+        public static void DrawCircle(this SKCanvas canvas, SKCircle circle, SKPaint paint)
+        {
+            canvas.DrawCircle(circle.Center.X, circle.Center.Y, circle.Radius, paint);
+        }
+
+        public static void DrawLine(this SKCanvas canvas, SKLine line, SKPaint paint)
+        {
+            canvas.DrawLine(line.P1.X, line.P1.Y, line.P2.X, line.P2.Y, paint);
+        }
+    }
+}

--- a/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/SKCircle.cs
+++ b/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/SKCircle.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Linq;
+
+namespace SkiaSharp.Extended.Svg
+{
+    internal struct SKCircle
+    {
+        public SKPoint Center { get; }
+
+        public float Radius { get; }
+
+        public SKCircle(SKPoint center, float radius)
+        {
+            Center = center;
+            Radius = radius;
+        }
+    }
+}

--- a/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/SKLine.cs
+++ b/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/SKLine.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Linq;
+
+namespace SkiaSharp.Extended.Svg
+{
+    internal struct SKLine
+    {
+        public SKPoint P1 { get; }
+        public SKPoint P2 { get; }
+
+        public SKLine(SKPoint p1, SKPoint p2)
+        {
+            P1 = p1;
+            P2 = p2;
+        }
+    }
+}

--- a/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/SKOval.cs
+++ b/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/SKOval.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Linq;
+
+namespace SkiaSharp.Extended.Svg
+{
+    internal struct SKOval
+    {
+        public SKPoint Center { get; }
+
+        public float RadiusX { get; }
+        public float RadiusY { get; }
+
+        public SKOval(SKPoint center, float rx, float ry)
+        {
+            Center = center;
+            RadiusX = rx;
+            RadiusY = ry;
+        }
+
+        public SKRect BoundingRect => SKRect.Create(Center.X - RadiusX, Center.Y - RadiusY, 2 * RadiusX, 2 * RadiusY);
+    }
+}

--- a/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/SKRoundedRect.cs
+++ b/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/SKRoundedRect.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Linq;
+
+namespace SkiaSharp.Extended.Svg
+{
+    internal struct SKRoundedRect
+    {
+        public SKRect Rect { get; }
+        public float RadiusX { get; }
+        public float RadiusY { get; }
+
+        public SKRoundedRect(SKRect rect, float rx, float ry)
+        {
+            Rect = rect;
+            RadiusX = rx;
+            RadiusY = ry;
+        }
+
+        public bool IsRounded()
+        {
+            return RadiusX > 0 || RadiusY > 0;
+        }
+    }
+}

--- a/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/SKSvg.cs
+++ b/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/SKSvg.cs
@@ -52,8 +52,8 @@ namespace SkiaSharp.Extended.Svg
 		private static readonly Regex unitRe = new Regex("px|pt|em|ex|pc|cm|mm|in");
 		private static readonly Regex percRe = new Regex("%");
 		private static readonly Regex fillUrlRe = new Regex(@"url\s*\(\s*#([^\)]+)\)");
-        private static readonly Regex clipPathUrlRe = new Regex(@"url\s*\(\s*#([^\)]+)\)");
-        private static readonly Regex keyValueRe = new Regex(@"\s*([\w-]+)\s*:\s*(.*)");
+		private static readonly Regex clipPathUrlRe = new Regex(@"url\s*\(\s*#([^\)]+)\)");
+		private static readonly Regex keyValueRe = new Regex(@"\s*([\w-]+)\s*:\s*(.*)");
 		private static readonly Regex WSRe = new Regex(@"\s{2,}");
 
 		private readonly Dictionary<string, XElement> defs = new Dictionary<string, XElement>();
@@ -264,12 +264,15 @@ namespace SkiaSharp.Extended.Svg
 			canvas.Save();
 			canvas.Concat(ref transform);
 
-            // clip-path
-            var clipPath = ReadClipPath(e.Attribute("clip-path")?.Value ?? string.Empty);
-            canvas?.ClipPath(clipPath);
+			// clip-path
+			var clipPath = ReadClipPath(e.Attribute("clip-path")?.Value ?? string.Empty);
+            if (clipPath != null)
+            {
+                canvas.ClipPath(clipPath);
+            }
 
-            // SVG element
-            var elementName = e.Name.LocalName;
+			// SVG element
+			var elementName = e.Name.LocalName;
 			var isGroup = elementName == "g";
 
 			// read style
@@ -287,9 +290,9 @@ namespace SkiaSharp.Extended.Svg
 				case "rect":
 					if (stroke != null || fill != null)
 					{
-                        var rect = ParseRoundedRect(e);
+						var rect = ParseRoundedRect(e);
 
-                        if (rect.IsRounded())
+						if (rect.IsRounded())
 						{
 							if (fill != null)
 								canvas.DrawRoundRect(rect, fill);
@@ -307,18 +310,18 @@ namespace SkiaSharp.Extended.Svg
 					break;
 				case "ellipse":
 					if (stroke != null || fill != null)
-                    {
-                        var oval = ParseOval(e);
-                        if (fill != null)
-                            canvas.DrawOval(oval, fill);
-                        if (stroke != null)
-                            canvas.DrawOval(oval, stroke);
-                    }
-                    break;
+					{
+						var oval = ParseOval(e);
+						if (fill != null)
+							canvas.DrawOval(oval, fill);
+						if (stroke != null)
+							canvas.DrawOval(oval, stroke);
+					}
+					break;
 				case "circle":
 					if (stroke != null || fill != null)
 					{
-                        var circle = ParseCircle(e);
+						var circle = ParseCircle(e);
 						if (fill != null)
 							canvas.DrawCircle(circle, fill);
 						if (stroke != null)
@@ -403,7 +406,7 @@ namespace SkiaSharp.Extended.Svg
 				case "line":
 					if (stroke != null)
 					{
-                        var line = ParseLine(e);
+						var line = ParseLine(e);
 						canvas.DrawLine(line, stroke);
 					}
 					break;
@@ -444,47 +447,47 @@ namespace SkiaSharp.Extended.Svg
 			canvas.Restore();
 		}
 
-        private SKOval ParseOval(XElement e)
-        {
-            var cx = ReadNumber(e.Attribute("cx"));
-            var cy = ReadNumber(e.Attribute("cy"));
-            var rx = ReadNumber(e.Attribute("rx"));
-            var ry = ReadNumber(e.Attribute("ry"));
+		private SKOval ParseOval(XElement e)
+		{
+			var cx = ReadNumber(e.Attribute("cx"));
+			var cy = ReadNumber(e.Attribute("cy"));
+			var rx = ReadNumber(e.Attribute("rx"));
+			var ry = ReadNumber(e.Attribute("ry"));
 
-            return new SKOval(new SKPoint(cx, cy), rx, ry);
-        }
+			return new SKOval(new SKPoint(cx, cy), rx, ry);
+		}
 
-        private SKCircle ParseCircle(XElement e)
-        {
-            var cx = ReadNumber(e.Attribute("cx"));
-            var cy = ReadNumber(e.Attribute("cy"));
-            var rr = ReadNumber(e.Attribute("r"));
+		private SKCircle ParseCircle(XElement e)
+		{
+			var cx = ReadNumber(e.Attribute("cx"));
+			var cy = ReadNumber(e.Attribute("cy"));
+			var rr = ReadNumber(e.Attribute("r"));
 
-            return new SKCircle(new SKPoint(cx, cy), rr);
-        }
+			return new SKCircle(new SKPoint(cx, cy), rr);
+		}
 
-        private SKLine ParseLine(XElement e)
-        {
-            var x1 = ReadNumber(e.Attribute("x1"));
-            var x2 = ReadNumber(e.Attribute("x2"));
-            var y1 = ReadNumber(e.Attribute("y1"));
-            var y2 = ReadNumber(e.Attribute("y2"));
+		private SKLine ParseLine(XElement e)
+		{
+			var x1 = ReadNumber(e.Attribute("x1"));
+			var x2 = ReadNumber(e.Attribute("x2"));
+			var y1 = ReadNumber(e.Attribute("y1"));
+			var y2 = ReadNumber(e.Attribute("y2"));
 
-            return new SKLine(new SKPoint(x1, y1), new SKPoint(x2, y2));
-        }
+			return new SKLine(new SKPoint(x1, y1), new SKPoint(x2, y2));
+		}
 
-        private SKRoundedRect ParseRoundedRect(XElement e)
-        {
-            var x = ReadNumber(e.Attribute("x"));
-            var y = ReadNumber(e.Attribute("y"));
-            var width = ReadNumber(e.Attribute("width"));
-            var height = ReadNumber(e.Attribute("height"));
-            var rx = ReadNumber(e.Attribute("rx"));
-            var ry = ReadNumber(e.Attribute("ry"));
-            var rect = SKRect.Create(x, y, width, height);
+		private SKRoundedRect ParseRoundedRect(XElement e)
+		{
+			var x = ReadNumber(e.Attribute("x"));
+			var y = ReadNumber(e.Attribute("y"));
+			var width = ReadNumber(e.Attribute("width"));
+			var height = ReadNumber(e.Attribute("height"));
+			var rx = ReadNumber(e.Attribute("rx"));
+			var ry = ReadNumber(e.Attribute("ry"));
+			var rect = SKRect.Create(x, y, width, height);
 
-            return new SKRoundedRect(rect, rx, ry);
-        }
+			return new SKRoundedRect(rect, rx, ry);
+		}
 
 		private void ReadText(XElement e, SKCanvas canvas, SKPaint stroke, SKPaint fill)
 		{
@@ -983,95 +986,95 @@ namespace SkiaSharp.Extended.Svg
 			return t;
 		}
 
-        private SKPath ReadClipPath(string raw)
-        {
-            if (string.IsNullOrWhiteSpace(raw))
-            {
-                return null;
-            }
+		private SKPath ReadClipPath(string raw)
+		{
+			if (string.IsNullOrWhiteSpace(raw))
+			{
+				return null;
+			}
 
-            SKPath result = null;
-            var read = false;
-            var urlM = clipPathUrlRe.Match(raw);
-            if (urlM.Success)
-            {
-                var id = urlM.Groups[1].Value.Trim();
+			SKPath result = null;
+			var read = false;
+			var urlM = clipPathUrlRe.Match(raw);
+			if (urlM.Success)
+			{
+				var id = urlM.Groups[1].Value.Trim();
 
-                XElement defE;
-                if (defs.TryGetValue(id, out defE))
-                {
-                    result = ReadClipPathDefinition(defE);
-                    if (result != null)
-                    {
-                        read = true;
-                    }
-                }
-                else
-                {
-                    LogOrThrow($"Invalid clip-path url reference: {id}");
-                }
-            }
+				XElement defE;
+				if (defs.TryGetValue(id, out defE))
+				{
+					result = ReadClipPathDefinition(defE);
+					if (result != null)
+					{
+						read = true;
+					}
+				}
+				else
+				{
+					LogOrThrow($"Invalid clip-path url reference: {id}");
+				}
+			}
 
-            if (!read)
-            {
-                LogOrThrow($"Unsupported clip-path: {raw}");
-            }
+			if (!read)
+			{
+				LogOrThrow($"Unsupported clip-path: {raw}");
+			}
 
-            return result;
-        }
+			return result;
+		}
 
-        private SKPath ReadClipPathDefinition(XElement e)
-        {
-            if (e.Name.LocalName != "clipPath")
-            {
-                return null;
-            }
+		private SKPath ReadClipPathDefinition(XElement e)
+		{
+			if (e.Name.LocalName != "clipPath")
+			{
+				return null;
+			}
 
-            var result = new SKPath();
+			var result = new SKPath();
 
-            var ns = e.Name.Namespace;
-            foreach (var ce in e.Elements())
-            {
-                var elementName = ce.Name.LocalName;
-                switch (elementName)
-                {
-                    case "rect":
-                        var rect = ParseRoundedRect(ce);
-                        result.AddRoundedRect(rect.Rect, rect.RadiusX, rect.RadiusY);
-                        break;
-                    case "ellipse":
-                        var oval = ParseOval(ce);
-                        result.AddOval(oval.BoundingRect);
-                        break;
-                    case "circle":
-                        var circle = ParseCircle(ce);
-                        result.AddCircle(circle.Center.X, circle.Center.Y, circle.Radius);
-                        break;
-                    case "line":
-                        var line = ParseLine(ce);
-                        result.MoveTo(line.P1);
-                        result.LineTo(line.P2);
-                        break;
-                    case "path":
-                        var d = e.Attribute("d")?.Value;
-                        if (!string.IsNullOrWhiteSpace(d))
-                        {
-                            var path = SKPath.ParseSvgPathData(d);
-                            result.AddPath(path);
-                        }
-                        break;
-                    default:
-                        LogOrThrow($"SVG element '{elementName}' is not supported in clipPath.");
-                        break;
-                }
-                
-            }
+			var ns = e.Name.Namespace;
+			foreach (var ce in e.Elements())
+			{
+				var elementName = ce.Name.LocalName;
+				switch (elementName)
+				{
+					case "rect":
+						var rect = ParseRoundedRect(ce);
+						result.AddRoundedRect(rect.Rect, rect.RadiusX, rect.RadiusY);
+						break;
+					case "ellipse":
+						var oval = ParseOval(ce);
+						result.AddOval(oval.BoundingRect);
+						break;
+					case "circle":
+						var circle = ParseCircle(ce);
+						result.AddCircle(circle.Center.X, circle.Center.Y, circle.Radius);
+						break;
+					case "line":
+						var line = ParseLine(ce);
+						result.MoveTo(line.P1);
+						result.LineTo(line.P2);
+						break;
+					case "path":
+						var d = e.Attribute("d")?.Value;
+						if (!string.IsNullOrWhiteSpace(d))
+						{
+							var path = SKPath.ParseSvgPathData(d);
+							result.AddPath(path);
+						}
+						break;
+					default:
+						LogOrThrow($"SVG element '{elementName}' is not supported in clipPath.");
+						break;
+				}
+				
+			}
 
-            return result;
+			return result;
 
-        }
+		}
 
-        private SKPath ReadPolyPath(string pointsData, bool closePath)
+		private SKPath ReadPolyPath(string pointsData, bool closePath)
 		{
 			var path = new SKPath();
 			var points = pointsData.Split(new[] { ' ', ',' }, StringSplitOptions.RemoveEmptyEntries);

--- a/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/SKSvg.cs
+++ b/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/SKSvg.cs
@@ -52,7 +52,8 @@ namespace SkiaSharp.Extended.Svg
 		private static readonly Regex unitRe = new Regex("px|pt|em|ex|pc|cm|mm|in");
 		private static readonly Regex percRe = new Regex("%");
 		private static readonly Regex fillUrlRe = new Regex(@"url\s*\(\s*#([^\)]+)\)");
-		private static readonly Regex keyValueRe = new Regex(@"\s*([\w-]+)\s*:\s*(.*)");
+        private static readonly Regex clipPathUrlRe = new Regex(@"url\s*\(\s*#([^\)]+)\)");
+        private static readonly Regex keyValueRe = new Regex(@"\s*([\w-]+)\s*:\s*(.*)");
 		private static readonly Regex WSRe = new Regex(@"\s{2,}");
 
 		private readonly Dictionary<string, XElement> defs = new Dictionary<string, XElement>();
@@ -263,8 +264,12 @@ namespace SkiaSharp.Extended.Svg
 			canvas.Save();
 			canvas.Concat(ref transform);
 
-			// SVG element
-			var elementName = e.Name.LocalName;
+            // clip-path
+            var clipPath = ReadClipPath(e.Attribute("clip-path")?.Value ?? string.Empty);
+            canvas?.ClipPath(clipPath);
+
+            // SVG element
+            var elementName = e.Name.LocalName;
 			var isGroup = elementName == "g";
 
 			// read style
@@ -282,52 +287,42 @@ namespace SkiaSharp.Extended.Svg
 				case "rect":
 					if (stroke != null || fill != null)
 					{
-						var x = ReadNumber(e.Attribute("x"));
-						var y = ReadNumber(e.Attribute("y"));
-						var width = ReadNumber(e.Attribute("width"));
-						var height = ReadNumber(e.Attribute("height"));
-						var rx = ReadNumber(e.Attribute("rx"));
-						var ry = ReadNumber(e.Attribute("ry"));
-						var rect = SKRect.Create(x, y, width, height);
-						if (rx > 0 || ry > 0)
+                        var rect = ParseRoundedRect(e);
+
+                        if (rect.IsRounded())
 						{
 							if (fill != null)
-								canvas.DrawRoundRect(rect, rx, ry, fill);
+								canvas.DrawRoundRect(rect, fill);
 							if (stroke != null)
-								canvas.DrawRoundRect(rect, rx, ry, stroke);
+								canvas.DrawRoundRect(rect, stroke);
 						}
 						else
 						{
 							if (fill != null)
-								canvas.DrawRect(rect, fill);
+								canvas.DrawRect(rect.Rect, fill);
 							if (stroke != null)
-								canvas.DrawRect(rect, stroke);
+								canvas.DrawRect(rect.Rect, stroke);
 						}
 					}
 					break;
 				case "ellipse":
 					if (stroke != null || fill != null)
-					{
-						var cx = ReadNumber(e.Attribute("cx"));
-						var cy = ReadNumber(e.Attribute("cy"));
-						var rx = ReadNumber(e.Attribute("rx"));
-						var ry = ReadNumber(e.Attribute("ry"));
-						if (fill != null)
-							canvas.DrawOval(cx, cy, rx, ry, fill);
-						if (stroke != null)
-							canvas.DrawOval(cx, cy, rx, ry, stroke);
-					}
-					break;
+                    {
+                        var oval = ParseOval(e);
+                        if (fill != null)
+                            canvas.DrawOval(oval, fill);
+                        if (stroke != null)
+                            canvas.DrawOval(oval, stroke);
+                    }
+                    break;
 				case "circle":
 					if (stroke != null || fill != null)
 					{
-						var cx = ReadNumber(e.Attribute("cx"));
-						var cy = ReadNumber(e.Attribute("cy"));
-						var rr = ReadNumber(e.Attribute("r"));
+                        var circle = ParseCircle(e);
 						if (fill != null)
-							canvas.DrawCircle(cx, cy, rr, fill);
+							canvas.DrawCircle(circle, fill);
 						if (stroke != null)
-							canvas.DrawCircle(cx, cy, rr, stroke);
+							canvas.DrawCircle(circle, stroke);
 					}
 					break;
 				case "path":
@@ -408,11 +403,8 @@ namespace SkiaSharp.Extended.Svg
 				case "line":
 					if (stroke != null)
 					{
-						var x1 = ReadNumber(e.Attribute("x1"));
-						var x2 = ReadNumber(e.Attribute("x2"));
-						var y1 = ReadNumber(e.Attribute("y1"));
-						var y2 = ReadNumber(e.Attribute("y2"));
-						canvas.DrawLine(x1, y1, x2, y2, stroke);
+                        var line = ParseLine(e);
+						canvas.DrawLine(line, stroke);
 					}
 					break;
 				case "switch":
@@ -451,6 +443,48 @@ namespace SkiaSharp.Extended.Svg
 			// restore matrix
 			canvas.Restore();
 		}
+
+        private SKOval ParseOval(XElement e)
+        {
+            var cx = ReadNumber(e.Attribute("cx"));
+            var cy = ReadNumber(e.Attribute("cy"));
+            var rx = ReadNumber(e.Attribute("rx"));
+            var ry = ReadNumber(e.Attribute("ry"));
+
+            return new SKOval(new SKPoint(cx, cy), rx, ry);
+        }
+
+        private SKCircle ParseCircle(XElement e)
+        {
+            var cx = ReadNumber(e.Attribute("cx"));
+            var cy = ReadNumber(e.Attribute("cy"));
+            var rr = ReadNumber(e.Attribute("r"));
+
+            return new SKCircle(new SKPoint(cx, cy), rr);
+        }
+
+        private SKLine ParseLine(XElement e)
+        {
+            var x1 = ReadNumber(e.Attribute("x1"));
+            var x2 = ReadNumber(e.Attribute("x2"));
+            var y1 = ReadNumber(e.Attribute("y1"));
+            var y2 = ReadNumber(e.Attribute("y2"));
+
+            return new SKLine(new SKPoint(x1, y1), new SKPoint(x2, y2));
+        }
+
+        private SKRoundedRect ParseRoundedRect(XElement e)
+        {
+            var x = ReadNumber(e.Attribute("x"));
+            var y = ReadNumber(e.Attribute("y"));
+            var width = ReadNumber(e.Attribute("width"));
+            var height = ReadNumber(e.Attribute("height"));
+            var rx = ReadNumber(e.Attribute("rx"));
+            var ry = ReadNumber(e.Attribute("ry"));
+            var rect = SKRect.Create(x, y, width, height);
+
+            return new SKRoundedRect(rect, rx, ry);
+        }
 
 		private void ReadText(XElement e, SKCanvas canvas, SKPaint stroke, SKPaint fill)
 		{
@@ -949,7 +983,95 @@ namespace SkiaSharp.Extended.Svg
 			return t;
 		}
 
-		private SKPath ReadPolyPath(string pointsData, bool closePath)
+        private SKPath ReadClipPath(string raw)
+        {
+            if (string.IsNullOrWhiteSpace(raw))
+            {
+                return null;
+            }
+
+            SKPath result = null;
+            var read = false;
+            var urlM = clipPathUrlRe.Match(raw);
+            if (urlM.Success)
+            {
+                var id = urlM.Groups[1].Value.Trim();
+
+                XElement defE;
+                if (defs.TryGetValue(id, out defE))
+                {
+                    result = ReadClipPathDefinition(defE);
+                    if (result != null)
+                    {
+                        read = true;
+                    }
+                }
+                else
+                {
+                    LogOrThrow($"Invalid clip-path url reference: {id}");
+                }
+            }
+
+            if (!read)
+            {
+                LogOrThrow($"Unsupported clip-path: {raw}");
+            }
+
+            return result;
+        }
+
+        private SKPath ReadClipPathDefinition(XElement e)
+        {
+            if (e.Name.LocalName != "clipPath")
+            {
+                return null;
+            }
+
+            var result = new SKPath();
+
+            var ns = e.Name.Namespace;
+            foreach (var ce in e.Elements())
+            {
+                var elementName = ce.Name.LocalName;
+                switch (elementName)
+                {
+                    case "rect":
+                        var rect = ParseRoundedRect(ce);
+                        result.AddRoundedRect(rect.Rect, rect.RadiusX, rect.RadiusY);
+                        break;
+                    case "ellipse":
+                        var oval = ParseOval(ce);
+                        result.AddOval(oval.BoundingRect);
+                        break;
+                    case "circle":
+                        var circle = ParseCircle(ce);
+                        result.AddCircle(circle.Center.X, circle.Center.Y, circle.Radius);
+                        break;
+                    case "line":
+                        var line = ParseLine(ce);
+                        result.MoveTo(line.P1);
+                        result.LineTo(line.P2);
+                        break;
+                    case "path":
+                        var d = e.Attribute("d")?.Value;
+                        if (!string.IsNullOrWhiteSpace(d))
+                        {
+                            var path = SKPath.ParseSvgPathData(d);
+                            result.AddPath(path);
+                        }
+                        break;
+                    default:
+                        LogOrThrow($"SVG element '{elementName}' is not supported in clipPath.");
+                        break;
+                }
+                
+            }
+
+            return result;
+
+        }
+
+        private SKPath ReadPolyPath(string pointsData, bool closePath)
 		{
 			var path = new SKPath();
 			var points = pointsData.Split(new[] { ' ', ',' }, StringSplitOptions.RemoveEmptyEntries);

--- a/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/SkiaSharp.Extended.Svg.Shared.projitems
+++ b/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/SkiaSharp.Extended.Svg.Shared.projitems
@@ -10,6 +10,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Properties\SkiaSharpSvgAssemblyInfo.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)SKCanvasExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)SKCircle.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)SKLine.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)SKOval.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)SKRoundedRect.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SKSvg.cs" />
   </ItemGroup>
 </Project>

--- a/SkiaSharp.Extended.Svg/tests/SkiaSharp.Extended.Svg.Tests/SKSvgTest.cs
+++ b/SkiaSharp.Extended.Svg/tests/SkiaSharp.Extended.Svg.Tests/SKSvgTest.cs
@@ -187,5 +187,34 @@ namespace SkiaSharp.Extended.Svg.Tests
 			Assert.AreEqual(fill, bmp.GetPixel(bmp.Width / 2, bmp.Height / 2));
 			Assert.AreEqual(background, bmp.GetPixel(5, 5));
 		}
+
+
+		[Test]
+		public void SvgRespectsClipPath()
+		{
+			var path = Path.Combine(PathToImages, "clipping.svg");
+			var background = (SKColor)0xffffff;
+			var fill = (SKColor)0x000000;
+
+			var svg = new SKSvg();
+			svg.Load(path);
+
+			var bmp = new SKBitmap((int)svg.CanvasSize.Width, (int)svg.CanvasSize.Height);
+			var canvas = new SKCanvas(bmp);
+			canvas.Clear(background);
+			
+			canvas.DrawPicture(svg.Picture);
+			canvas.Flush();
+
+			for (int x = 1; x < 20; x++)
+			{
+				for (int y = 1; y < 20; y++)
+				{
+					Assert.AreEqual(fill, bmp.GetPixel(x, y));
+					Assert.AreEqual(background, bmp.GetPixel(x + 20, y + 20));
+				}
+			}
+		}
+		
 	}
 }

--- a/SkiaSharp.Extended.Svg/tests/SkiaSharp.Extended.Svg.Tests/SkiaSharp.Extended.Svg.Tests.csproj
+++ b/SkiaSharp.Extended.Svg/tests/SkiaSharp.Extended.Svg.Tests/SkiaSharp.Extended.Svg.Tests.csproj
@@ -55,6 +55,9 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="images\clipping.svg">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="images\sketch.svg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -74,8 +77,6 @@
       <Name>SkiaSharp.Extended.Svg</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="images\" />
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/SkiaSharp.Extended.Svg/tests/SkiaSharp.Extended.Svg.Tests/images/clipping.svg
+++ b/SkiaSharp.Extended.Svg/tests/SkiaSharp.Extended.Svg.Tests/images/clipping.svg
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" standalone="no" ?>
+<svg xmlns="http://www.w3.org/2000/svg" fill="white" version="1.1">
+    <defs>
+        <clipPath id="myclip">
+            <rect width="20" height="20" />
+        </clipPath>
+    </defs>
+    <rect x="0" y="0" width="40" height="40" fill="#000000" fill-opacity="1" clip-path="url(#myclip)"/>
+</svg>


### PR DESCRIPTION
This implements support for clipPath elements, that can use rect, ellipse, circle, line and path elements to define clipping.
As I already mentioned in #13. all tests that compare specific bitmap pixels fail on my machine (ie. not only the tests I added, but also existing ones). I hope this is an issue on my machine only.