### PR TITLE
Fixes previous element gradient fill is used when current element has a custom fill & global style support

### DIFF
--- a/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/Helpers/CssHelpers.cs
+++ b/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/Helpers/CssHelpers.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace SkiaSharp.Helpers
+{
+    internal static class CssHelpers
+    {
+        public static Dictionary<string, string> ParseSelectors(string css)
+        {
+            return
+                Regex
+                    .Matches(css.Minify(), @"(?<selectors>[a-z0-9_\-\.,\s#]+)\s*{(?<declarations>.+?)}", RegexOptions.IgnoreCase)
+                    .Cast<Match>()
+                    .Select(m => Regex
+                        .Split(m.Groups["selectors"].Value, @",")
+                        .Where(s => !string.IsNullOrEmpty(s))
+                        .Select(selector => new KeyValuePair<string, string>(
+                            key: selector.Trim().ToLowerInvariant(),
+                            value: m.Groups["declarations"].Value.Trim())))
+                    .SelectMany(x => x)
+                    .ToDictionary(x => x.Key, x => x.Value);
+        }
+
+        static string Minify(this string css) => Regex.Replace(css, @"(\r\n|\r|\n)", string.Empty);
+    }
+}

--- a/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/SKSvg.cs
+++ b/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/SKSvg.cs
@@ -876,8 +876,7 @@ namespace SkiaSharp.Extended.Svg
 				}
 				else
 				{
-					if (fillPaint == null)
-						fillPaint = CreatePaint();
+					fillPaint = CreatePaint();
 
 					SKColor color;
 					if (ColorHelper.TryParse(fill, out color))

--- a/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/SKSvg.cs
+++ b/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/SKSvg.cs
@@ -57,6 +57,7 @@ namespace SkiaSharp.Extended.Svg
 		private static readonly Regex WSRe = new Regex(@"\s{2,}");
 
 		private readonly Dictionary<string, XElement> defs = new Dictionary<string, XElement>();
+        private Dictionary<string, string> styles;
 		private readonly XmlReaderSettings xmlReaderSettings = new XmlReaderSettings()
 		{
 			DtdProcessing = DtdProcessing.Ignore,
@@ -290,6 +291,11 @@ namespace SkiaSharp.Extended.Svg
 			// parse elements
 			switch (elementName)
 			{
+                case "style":
+                    {
+                        styles = CssHelpers.ParseSelectors(e.Value);
+                        break;
+                    },
 				case "image":
 					{
 						var uri = ReadHrefString(e);
@@ -746,24 +752,47 @@ namespace SkiaSharp.Extended.Svg
 			return d;
 		}
 
-		private Dictionary<string, string> ReadStyle(XElement e)
-		{
-			// get from local attributes
-			var dic = e.Attributes().Where(a => HasSvgNamespace(a.Name)).ToDictionary(k => k.Name.LocalName, v => v.Value);
+        private Dictionary<string, string> ReadStyle(XElement e)
+        {
+            // get from local attributes
+            var dic = e.Attributes().Where(a => HasSvgNamespace(a.Name)).ToDictionary(k => k.Name.LocalName, v => v.Value);
 
-			var style = e.Attribute("style")?.Value;
-			if (!string.IsNullOrWhiteSpace(style))
-			{
-				// get from stlye attribute
-				var styleDic = ReadStyle(style);
+            string className;
+            string glStyle;
 
-				// overwrite
-				foreach (var pair in styleDic)
-					dic[pair.Key] = pair.Value;
-			}
+            if (styles != null && styles.TryGetValue(e.Name.LocalName, out glStyle))
+            {
+                // get from stlye attribute
+                var styleDic = ReadStyle(glStyle);
 
-			return dic;
-		}
+                // overwrite
+                foreach (var pair in styleDic)
+                    dic[pair.Key] = pair.Value;
+            }
+            if (styles != null && dic.TryGetValue("class", out className)
+                && styles.TryGetValue("." + className, out glStyle))
+            {
+                // get from stlye attribute
+                var styleDic = ReadStyle(glStyle);
+
+                // overwrite
+                foreach (var pair in styleDic)
+                    dic[pair.Key] = pair.Value;
+            }
+
+            var style = e.Attribute("style")?.Value;
+            if (!string.IsNullOrWhiteSpace(style))
+            {
+                // get from stlye attribute
+                var styleDic = ReadStyle(style);
+
+                // overwrite
+                foreach (var pair in styleDic)
+                    dic[pair.Key] = pair.Value;
+            }
+
+            return dic;
+        }
 
 		private static bool HasSvgNamespace(XName name)
 		{

--- a/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/SkiaSharp.Extended.Svg.Shared.projitems
+++ b/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/SkiaSharp.Extended.Svg.Shared.projitems
@@ -16,5 +16,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)SKOval.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SKRoundedRect.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SKSvg.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Helpers\CssHelpers.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="$(MSBuildThisFileDirectory)Helpers\" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
1. Sample file which is not working correctly without the fix:

```XML
<svg xmlns="http://www.w3.org/2000/svg" data-name="Layer 1" viewBox="0 0 41 41">
    <defs>
        <linearGradient id="a" x1="5.29" x2="36.27" y1="5.29" y2="36.27" gradientUnits="userSpaceOnUse">
            <stop offset="0" stop-color="#583ce5" />
            <stop offset=".34" stop-color="#a725b2" />
            <stop offset=".67" stop-color="#f4183f" />
            <stop offset="1" stop-color="#ffc34a" />
        </linearGradient>
    </defs>
    <circle cx="20.5" cy="20.5" r="20.5" fill="url(#a)" />
    <path fill="#ffffff" d="M25.52 30.77h-9.53a5.79 5.79 0 0 1-1.68-.44 5.87 5.87 0 0 1-2.07-1.48 5.76 5.76 0 0 1-1.55-3.92v-8.75a5.55 5.55 0 0 1 .19-1.43 5.91 5.91 0 0 1 2.38-3.41 5.66 5.66 0 0 1 3.29-1.06h8.7a6 6 0 0 1 1.4.16 6 6 0 0 1 4.57 5.75v8.71a5.71 5.71 0 0 1-.46 2.24 5.94 5.94 0 0 1-2.6 2.86 5.79 5.79 0 0 1-2.26.72zM21 11.81h-4.81a4 4 0 0 0-1.73.55 4.27 4.27 0 0 0-2.2 3.83v8.56a4.68 4.68 0 0 0 .1 1 4.37 4.37 0 0 0 4.24 3.44h8.63a4.91 4.91 0 0 0 .77-.06 4.17 4.17 0 0 0 2.15-1 4.29 4.29 0 0 0 1.5-3.33v-8.55a4.68 4.68 0 0 0 0-.53 4.37 4.37 0 0 0-4.3-3.87c-1.49-.05-2.95-.04-4.35-.04z" />
    <path fill="#ffffff" d="M26.48 20.5A5.53 5.53 0 1 1 21 15a5.55 5.55 0 0 1 5.48 5.5zm-9.48 0a4 4 0 1 0 4-4 3.94 3.94 0 0 0-4 4z" />
    <circle fill="#ffffff" cx="26.87" cy="14.58" r="1.19" transform="rotate(-89.88 26.873 14.577)" />
</svg>
```

2. Also added global style attrbute support
