### PR TITLE
Add support for the mask element.

### DIFF
--- a/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/SKSvg.cs
+++ b/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/SKSvg.cs
@@ -379,6 +379,22 @@ namespace SkiaSharp.Extended.Svg
 						}
 					}
 					break;
+				case "mask":
+					if (e.HasElements)
+					{
+						if (fill != null)
+						{
+							fill.ColorFilter = SKColorFilter.CreateBlendMode(fill.Color, SKBlendMode.SrcIn);
+							fill.FilterQuality = SKFilterQuality.Medium;
+							foreach (var gElement in e.Elements())
+							{
+								ReadElement(gElement, canvas, stroke?.Clone(), fill?.Clone());
+							}
+						} else {
+							LogOrThrow($"Fill missing for '{elementName}' element");
+						}
+					}
+					break;
 				case "defs":
 				case "title":
 				case "desc":


### PR DESCRIPTION
This provides support for the mask element used a lot by Sketch when exporting to SVG.
I can't attach the example so here it is:

```
<?xml version="1.0" encoding="UTF-8" ?>
<svg width="50px" height="50px" viewBox="0 0 50 50" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
    <!-- Generator: Sketch 47.1 (45422) - http://www.bohemiancoding.com/sketch -->
    <title>icons/vas-plus</title>
    <desc>Created with Sketch.</desc>
    <defs>
        <path d="M28.5,21.5 L40.5,21.5 C42.4329966,21.5 44,23.0670034 44,25 C44,26.9329966 42.4329966,28.5 40.5,28.5 L28.5,28.5 L28.5,40.5 C28.5,42.4329966 26.9329966,44 25,44 C23.0670034,44 21.5,42.4329966 21.5,40.5 L21.5,28.5 L9.5,28.5 C7.56700338,28.5 6,26.9329966 6,25 C6,23.0670034 7.56700338,21.5 9.5,21.5 L21.5,21.5 L21.5,9.5 C21.5,7.56700338 23.0670034,6 25,6 C26.9329966,6 28.5,7.56700338 28.5,9.5 L28.5,21.5 Z" id="path-1"></path>
    </defs>
    <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
        <g id="icons/vas-plus">
            <mask id="mask-2" fill="red">
                <use xlink:href="#path-1"></use>
            </mask>
        </g>
    </g>
</svg>
```