### PR TITLE
Add support for SVG's with masks.

### DIFF
--- a/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/SKSVGMask.cs
+++ b/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/SKSVGMask.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Xml.Linq;
+
+namespace SkiaSharp.Extended.Svg
+{
+	internal class SKSvgMask
+	{
+		public SKSvgMask(SKPaint fill, XElement element)
+		{
+			Fill = fill.Clone();
+			Element = element;
+		}
+
+		public SKPaint Fill { get; }
+
+		public XElement Element { get; }
+	}
+}


### PR DESCRIPTION
Add support for SVG's with masks, such as the following one exported from Sketch

```
<?xml version="1.0" encoding="UTF-8" ?>
<svg width="50px" height="50px" viewBox="0 0 50 50" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
    <!-- Generator: Sketch 47.1 (45422) - http://www.bohemiancoding.com/sketch -->
    <title>icons/vas-plus</title>
    <desc>Created with Sketch.</desc>
    <defs>
        <path d="M28.5,21.5 L40.5,21.5 C42.4329966,21.5 44,23.0670034 44,25 C44,26.9329966 42.4329966,28.5 40.5,28.5 L28.5,28.5 L28.5,40.5 C28.5,42.4329966 26.9329966,44 25,44 C23.0670034,44 21.5,42.4329966 21.5,40.5 L21.5,28.5 L9.5,28.5 C7.56700338,28.5 6,26.9329966 6,25 C6,23.0670034 7.56700338,21.5 9.5,21.5 L21.5,21.5 L21.5,9.5 C21.5,7.56700338 23.0670034,6 25,6 C26.9329966,6 28.5,7.56700338 28.5,9.5 L28.5,21.5 Z" id="path-1"></path>
    </defs>
    <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
        <g id="icons/vas-plus">
            <mask id="mask-2" fill="red">
                <use xlink:href="#path-1"></use>
            </mask>
        </g>
        <g id="icons/colours/light" mask="url(#mask-2)" fill="#DDDDDD">
            <rect id="Rectangle-11" x="0" y="0" width="50" height="50"></rect>
        </g>
    </g>
</svg>
```

Masks are read and cached into an SKPicture and blended with the cached layer as recommended here https://groups.google.com/forum/#!topic/skia-discuss/ewpuYlM-X3o