### PR TITLE
Disable log compression in build.groovy

### DIFF
--- a/build.groovy
+++ b/build.groovy
@@ -8,9 +8,10 @@ import groovy.transform.Field
 @Field def stashes = []
 @Field def customEnv = []
 
-properties([
-    compressBuildLog()
-])
+// compression is incompatible with JEP-210 right now
+//properties([
+//    compressBuildLog()
+//])
 
 // ============================================================================
 // Stages


### PR DESCRIPTION
It's currently incompatible with the changes Jenkins is making as part of JEP-210: https://issues.jenkins-ci.org/browse/JENKINS-54680