### PR TITLE
Various fixes

### DIFF
--- a/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/ColorHelper.cs
+++ b/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/ColorHelper.cs
@@ -9,6 +9,12 @@ namespace SkiaSharp.Extended.Svg
 
 		public static bool TryParse(string str, out SKColor color)
 		{
+			if (str == "transparent")
+			{
+				color = SKColors.Transparent;
+				return true;
+			}
+
 			if (str.StartsWith("rgb(", StringComparison.Ordinal))
 			{
 				str = str.Substring(4, str.Length - 4).TrimEnd(')');

--- a/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/CssHelpers.cs
+++ b/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/CssHelpers.cs
@@ -14,13 +14,13 @@ namespace SkiaSharp.Extended.Svg
 
 			var items =
 				Regex
-					.Matches(css.Minify(), @"(?<selectors>[a-z0-9_\-\.,\s#]+)\s*{(?<declarations>.+?)}", RegexOptions.IgnoreCase)
+					.Matches(css.Minify(), @"(?<selectors>[A-Za-z0-9_\-\.,\s#]+)\s*{(?<declarations>.+?)}", RegexOptions.IgnoreCase)
 					.Cast<Match>()
 					.Select(m => Regex
 						.Split(m.Groups["selectors"].Value, @",")
 						.Where(s => !string.IsNullOrEmpty(s))
 						.Select(selector => new KeyValuePair<string, string>(
-							key: selector.Trim().ToLowerInvariant(),
+							key: selector.Trim(),
 							value: m.Groups["declarations"].Value.Trim())))
 					.SelectMany(x => x);
 
@@ -31,5 +31,99 @@ namespace SkiaSharp.Extended.Svg
 		}
 
 		static string Minify(this string css) => Regex.Replace(css, @"(\r\n|\r|\n)", string.Empty).Trim();
+
+		public static Dictionary<string, string> AddFontShorthand(Dictionary<string, string> style, string value)
+		{
+			var splitted = value.Split(new char[0], StringSplitOptions.RemoveEmptyEntries); // split by whitespaces
+			string fontStyle = null;
+			string fontVariant = null;
+			string fontWeight = null;
+			string fontSize = null;
+			string lineHeight = null;
+			string fontFamily = null;
+
+			foreach (var item in splitted)
+			{
+				switch (item)
+				{
+					case "normal":
+					case "inherit":
+					case "initial":
+						if (string.IsNullOrEmpty(fontStyle))
+							fontStyle = item;
+						else if (string.IsNullOrEmpty(fontVariant))
+							fontVariant = item;
+						else if (string.IsNullOrEmpty(fontWeight))
+							fontWeight = item;
+						break;
+
+					case "italic":
+					case "oblique":
+						fontStyle = item;
+						break;
+
+					case "small-caps":
+						fontVariant = item;
+						break;
+
+					case "bold":
+					case "bolder":
+					case "lighter":
+					case "100":
+					case "200":
+					case "300":
+					case "400":
+					case "500":
+					case "600":
+					case "700":
+					case "800":
+					case "900":
+					case "1000":
+						fontWeight = item;
+						break;
+
+					default:
+						if (fontSize == null)
+						{
+							var parts = item.Split('/');
+							fontSize = parts[0];
+							if (parts.Length > 1)
+								lineHeight = parts[1];
+							break;
+						}
+
+						if (string.IsNullOrEmpty(fontFamily))
+						{
+							fontFamily = item;
+						}
+						else
+						{
+							fontFamily = string.Concat(fontFamily, " ", item);
+						}
+
+						break;
+				}
+			}
+
+			if (!string.IsNullOrWhiteSpace(fontStyle))
+				style["font-style"] = fontStyle;
+
+			if (!string.IsNullOrWhiteSpace(fontVariant))
+				style["font-variant"] = fontVariant;
+
+			if (!string.IsNullOrWhiteSpace(fontWeight))
+				style["font-weight"] = fontWeight;
+
+			if (!string.IsNullOrWhiteSpace(fontSize))
+				style["font-size"] = fontSize;
+
+			if (!string.IsNullOrWhiteSpace(lineHeight))
+				style["line-height"] = lineHeight;
+
+			if (!string.IsNullOrWhiteSpace(fontFamily))
+				style["font-family"] = fontFamily;
+
+			return style;
+		}
 	}
 }

--- a/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/CssHelpers.cs
+++ b/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/CssHelpers.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace SkiaSharp.Extended.Svg
+{
+	internal static class CssHelpers
+	{
+		public static void ParseSelectors(string css, Dictionary<string, string> destination)
+		{
+			if (string.IsNullOrWhiteSpace(css))
+				return;
+
+			var items =
+				Regex
+					.Matches(css.Minify(), @"(?<selectors>[a-z0-9_\-\.,\s#]+)\s*{(?<declarations>.+?)}", RegexOptions.IgnoreCase)
+					.Cast<Match>()
+					.Select(m => Regex
+						.Split(m.Groups["selectors"].Value, @",")
+						.Where(s => !string.IsNullOrEmpty(s))
+						.Select(selector => new KeyValuePair<string, string>(
+							key: selector.Trim().ToLowerInvariant(),
+							value: m.Groups["declarations"].Value.Trim())))
+					.SelectMany(x => x);
+
+			foreach (var item in items)
+			{
+				destination.Add(item.Key, item.Value);
+			}
+		}
+
+		static string Minify(this string css) => Regex.Replace(css, @"(\r\n|\r|\n)", string.Empty).Trim();
+	}
+}

--- a/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/SKSvg.cs
+++ b/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/SKSvg.cs
@@ -676,7 +676,7 @@ namespace SkiaSharp.Extended.Svg
 
 			// textAlign is used for all spans within the <text> element. If different textAligns would be needed, it is necessary to use
 			// several <text> elements instead of <tspan> elements
-			fill.TextAlign = SKTextAlign.Center;  // fixed alignment for all spans
+			fill.TextAlign = SKTextAlign.Left;  // fixed alignment for all spans
 
 			ReadTextElement(e, spans, textAlign, baselineShift, stroke, fill);
 

--- a/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/SKSvgMask.cs
+++ b/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/SKSvgMask.cs
@@ -5,11 +5,14 @@ namespace SkiaSharp.Extended.Svg
 {
 	internal class SKSvgMask
 	{
-		public SKSvgMask(SKPaint fill, XElement element)
+		public SKSvgMask(SKPaint stroke, SKPaint fill, XElement element)
 		{
-			Fill = fill.Clone();
+			Stroke = stroke?.Clone();
+			Fill = fill?.Clone();
 			Element = element;
 		}
+
+		public SKPaint Stroke { get; }
 
 		public SKPaint Fill { get; }
 

--- a/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/SKSvgMask.cs
+++ b/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/SKSvgMask.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Xml.Linq;
+
+namespace SkiaSharp.Extended.Svg
+{
+	internal class SKSvgMask
+	{
+		public SKSvgMask(SKPaint fill, XElement element)
+		{
+			Fill = fill.Clone();
+			Element = element;
+		}
+
+		public SKPaint Fill { get; }
+
+		public XElement Element { get; }
+	}
+}

--- a/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/SKTextSpan.cs
+++ b/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.Shared/SKTextSpan.cs
@@ -2,9 +2,10 @@
 {
 	internal class SKTextSpan
 	{
-		public SKTextSpan(string text, SKPaint fill, float? x = null, float? y = null, float? baselineShift = null)
+		public SKTextSpan(string text, SKPaint stroke, SKPaint fill, float? x = null, float? y = null, float? baselineShift = null)
 		{
 			Text = text;
+			Stroke = stroke;
 			Fill = fill;
 			X = x;
 			Y = y;
@@ -12,6 +13,8 @@
 		}
 
 		public string Text { get; }
+
+		public SKPaint Stroke { get; }
 
 		public SKPaint Fill { get; }
 

--- a/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.csproj
+++ b/SkiaSharp.Extended.Svg/source/SkiaSharp.Extended.Svg.csproj
@@ -41,6 +41,12 @@
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
     <PackageReference Include="SkiaSharp" Version="1.68.0" />


### PR DESCRIPTION
- https://github.com/mono/SkiaSharp.Extended/pull/74 merged
- https://github.com/mono/SkiaSharp.Extended/pull/36 merged

Fixes: 
- `style` element parsing, `style` element inside `defs` support
- fixed parsing of nested `tspan` elements (which was ignored)
- `text` support fixes
- ReadElementSize fixes
- clipPath fixes 
- fixes MeasureTextWidth throwing exception
- text stroke support, fixes for reading text styles
- CSS Fix for non lowercase class names parsing
- font shorthand support, various text handling enhancements
- initial/inherit fill/stroke support
- added gradient support for stroke
- handle 'a' tag element
- mask support fixes
- added `CancellationToken` support when parsing