### PR TITLE
Do not load the animation directly

### DIFF
--- a/samples/Maui/SkiaSharpDemo/Demos/Lottie/LottiePage.xaml
+++ b/samples/Maui/SkiaSharpDemo/Demos/Lottie/LottiePage.xaml
@@ -11,7 +11,9 @@
                                Source="Lottie/trophy.json"
                                Duration="{Binding Duration}"
                                Progress="{Binding Progress}"
-                               IsRunning="{Binding IsBusy}"/>
+                               IsRunning="{Binding IsBusy}"
+                               AnimationFailed="OnAnimationFailed"
+                               AnimationLoaded="OnAnimationLoaded" />
 
         <BoxView Color="Green" Opacity="0.5" CornerRadius="12"
                  WidthRequest="25" HeightRequest="24" Margin="24"

--- a/samples/Maui/SkiaSharpDemo/Demos/Lottie/LottiePage.xaml.cs
+++ b/samples/Maui/SkiaSharpDemo/Demos/Lottie/LottiePage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows.Input;
+﻿using System.Diagnostics;
+using System.Windows.Input;
 
 namespace SkiaSharpDemo.Demos;
 
@@ -60,4 +61,14 @@ public partial class LottiePage : ContentPage
 
 	private void OnPlayPause() =>
 		IsBusy = !IsBusy;
+
+	private void OnAnimationFailed(object sender, EventArgs e)
+	{
+		Debug.WriteLine("Failed to load Lottie animation.");
+	}
+
+	private void OnAnimationLoaded(object sender, EventArgs e)
+	{
+		Debug.WriteLine("Lottie animation loaded.");
+	}
 }

--- a/source/SkiaSharp.Extended.UI/Controls/Lottie/SKLottieView.shared.cs
+++ b/source/SkiaSharp.Extended.UI/Controls/Lottie/SKLottieView.shared.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.Maui.Dispatching;
-
-namespace SkiaSharp.Extended.UI.Controls;
+﻿namespace SkiaSharp.Extended.UI.Controls;
 
 public class SKLottieView : SKAnimatedSurfaceView
 {

--- a/source/SkiaSharp.Extended.UI/Controls/Lottie/SKLottieView.shared.cs
+++ b/source/SkiaSharp.Extended.UI/Controls/Lottie/SKLottieView.shared.cs
@@ -1,4 +1,6 @@
-﻿namespace SkiaSharp.Extended.UI.Controls;
+﻿using Microsoft.Maui.Dispatching;
+
+namespace SkiaSharp.Extended.UI.Controls;
 
 public class SKLottieView : SKAnimatedSurfaceView
 {
@@ -207,7 +209,7 @@ public class SKLottieView : SKAnimatedSurfaceView
 		{
 			try
 			{
-				animation = await imageSource.LoadAnimationAsync(cancellationToken);
+				animation = await Task.Run(() => imageSource.LoadAnimationAsync(cancellationToken));
 			}
 			catch
 			{


### PR DESCRIPTION
**Description of Change**

It may return immediately and the view will not be set up to recieve events. Also, it will be loading the animation (which could take a few ms) on the UI thread.

**Bugs Fixed**

- Invalid image sources in the XAML fail, but before the lottie view events are attached

**API Changes**

<!-- REPLACE THIS COMMENT
List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`
 
-->

**Behavioral Changes**

All animations initiate loading on a background thread.

**PR Checklist**

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation
