### PR TITLE
Feature/is animation enabled

### DIFF
--- a/docs/api/ui-maui/skconfettiview.md
+++ b/docs/api/ui-maui/skconfettiview.md
@@ -10,11 +10,11 @@ The confetti view is a container for one or more systems of particles.
 
 The main property of a confetti view is the `Systems` property:
 
-| Property        | Type                          | Description |
-| :-------------- | :---------------------------- | :---------- |
-| **Systems**     | `SKConfettiSystemCollection`  | The collection of [systems](#system) in the view. |
-| **IsRunning**   | `bool`                        | Controls whether the all systems are running or not. |
-| **IsComplete**  | `bool`                        | A value that indicates whether all systems are complete. |
+| Property               | Type                          | Description |
+| :--------------------- | :---------------------------- | :---------- |
+| **Systems**            | `SKConfettiSystemCollection`  | The collection of [systems](#system) in the view. |
+| **IsAnimationEnabled** | `bool`                        | Determines whether the control will play the animation provided. |
+| **IsComplete**         | `bool`                        | A value that indicates whether all systems are complete. |
 
 ## Parts
 

--- a/docs/api/ui-maui/sklottieview.md
+++ b/docs/api/ui-maui/sklottieview.md
@@ -10,15 +10,15 @@ The Lottie view is a animated view that can playback Lottie files.
 
 There are several properties that can be used to control th animation playback:
 
-| Property         | Type                   | Description |
-| :--------------- | :--------------------- | :---------- |
-| **Source**       | `SKLottieImageSource`  | The Lottie [image source](#source) to playback in the view. |
-| **Duration**     | `TimeSpan`             | A value indicating the total duration of the animation. |
-| **Progress**     | `TimeSpan`             | The current playback progress of the animation. |
-| **RepeatCount**  | `int`                  | The number of times to repeat the animation. Default is 0 (no repeat). |
-| **RepeatMode**   | `SKLottieRepeatMode`   | The way in which to repeat the animation. Default is `Restart`. |
-| **IsRunning**    | `bool`                 | Controls whether the all systems are running or not. |
-| **IsComplete**   | `bool`                 | A value that indicates whether all systems are complete. |
+| Property               | Type                   | Description |
+| :--------------------- | :--------------------- | :---------- |
+| **Source**             | `SKLottieImageSource`  | The Lottie [image source](#source) to playback in the view. |
+| **Duration**           | `TimeSpan`             | A value indicating the total duration of the animation. |
+| **Progress**           | `TimeSpan`             | The current playback progress of the animation. |
+| **RepeatCount**        | `int`                  | The number of times to repeat the animation. Default is 0 (no repeat). |
+| **RepeatMode**         | `SKLottieRepeatMode`   | The way in which to repeat the animation. Default is `Restart`. |
+| **IsAnimationEnabled** | `bool`                 | Determines whether the control will play the animation provided. |
+| **IsComplete**         | `bool`                 | A value that indicates whether all systems are complete. |
 
 ## Events
 

--- a/samples/Maui/SkiaSharpDemo/Demos/Lottie/LottiePage.xaml
+++ b/samples/Maui/SkiaSharpDemo/Demos/Lottie/LottiePage.xaml
@@ -11,7 +11,7 @@
                                Source="Lottie/trophy.json"
                                Duration="{Binding Duration}"
                                Progress="{Binding Progress}"
-                               IsRunning="{Binding IsBusy}"
+                               IsAnimationEnabled="{Binding IsBusy}"
                                AnimationFailed="OnAnimationFailed"
                                AnimationLoaded="OnAnimationLoaded" />
 

--- a/source/SkiaSharp.Extended.UI/Controls/Confetti/SKConfettiView.shared.cs
+++ b/source/SkiaSharp.Extended.UI/Controls/Confetti/SKConfettiView.shared.cs
@@ -27,11 +27,11 @@ public class SKConfettiView : SKAnimatedSurfaceView
 		SizeChanged += OnSizeChanged;
 		PropertyChanged += (_, e) =>
 		{
-			if (nameof(IsRunning).Equals(e.PropertyName, StringComparison.OrdinalIgnoreCase))
+			if (nameof(IsAnimationEnabled).Equals(e.PropertyName, StringComparison.OrdinalIgnoreCase))
 				OnIsRunningPropertyChanged();
 		};
 
-		IsRunning = true;
+		IsAnimationEnabled = true;
 
 		OnSystemsPropertyChanged(this, null, Systems);
 	}
@@ -100,7 +100,7 @@ public class SKConfettiView : SKAnimatedSurfaceView
 			foreach (SKConfettiSystem system in e.NewItems)
 			{
 				system.UpdateEmitterBounds(Width, Height);
-				system.IsRunning = IsRunning;
+				system.IsRunning = IsAnimationEnabled;
 			}
 
 			Invalidate();
@@ -116,7 +116,7 @@ public class SKConfettiView : SKAnimatedSurfaceView
 
 		foreach (var system in Systems)
 		{
-			system.IsRunning = IsRunning;
+			system.IsRunning = IsAnimationEnabled;
 		}
 	}
 

--- a/source/SkiaSharp.Extended.UI/Controls/Lottie/SKLottieView.shared.cs
+++ b/source/SkiaSharp.Extended.UI/Controls/Lottie/SKLottieView.shared.cs
@@ -54,7 +54,7 @@ public class SKLottieView : SKAnimatedSurfaceView
 	{
 		Themes.SKLottieViewResources.EnsureRegistered();
 
-		IsRunning = true;
+		IsAnimationEnabled = true;
 	}
 
 	public SKLottieImageSource? Source
@@ -191,7 +191,7 @@ public class SKLottieView : SKAnimatedSurfaceView
 				repeatsCompleted >= totalRepeatCount;
 		}
 
-		if (!IsRunning)
+		if (!IsAnimationEnabled)
 			Invalidate();
 	}
 
@@ -226,7 +226,7 @@ public class SKLottieView : SKAnimatedSurfaceView
 		Progress = TimeSpan.Zero;
 		Duration = animation?.Duration ?? TimeSpan.Zero;
 
-		if (!IsRunning)
+		if (!IsAnimationEnabled)
 			Invalidate();
 	}
 

--- a/source/SkiaSharp.Extended.UI/Controls/SKAnimatedSurfaceView.shared.cs
+++ b/source/SkiaSharp.Extended.UI/Controls/SKAnimatedSurfaceView.shared.cs
@@ -2,13 +2,13 @@
 
 public class SKAnimatedSurfaceView : SKSurfaceView
 {
-	public static readonly BindableProperty IsRunningProperty = BindableProperty.Create(
-		nameof(IsRunning),
+	public static readonly BindableProperty IsAnimationEnabledProperty = BindableProperty.Create(
+		nameof(IsAnimationEnabled),
 		typeof(bool),
 		typeof(SKAnimatedSurfaceView),
 		false,
-		BindingMode.TwoWay,
-		propertyChanged: OnIsRunningPropertyChanged);
+		BindingMode.OneWay,
+		propertyChanged: OnIsAnimationEnabledPropertyChanged);
 
 	private readonly SKFrameCounter frameCounter = new SKFrameCounter();
 
@@ -17,10 +17,13 @@ public class SKAnimatedSurfaceView : SKSurfaceView
 		Loaded += OnLoaded;
 	}
 
-	public bool IsRunning
+	/// <summary>
+	/// Gets or sets a value indicating whether this control will play the animation provided.
+	/// </summary>
+	public bool IsAnimationEnabled
 	{
-		get => (bool)GetValue(IsRunningProperty);
-		set => SetValue(IsRunningProperty, value);
+		get => (bool)GetValue(IsAnimationEnabledProperty);
+		set => SetValue(IsAnimationEnabledProperty, value);
 	}
 
 	protected virtual void Update(TimeSpan deltaTime)
@@ -45,29 +48,29 @@ public class SKAnimatedSurfaceView : SKSurfaceView
 
 	private void UpdateCore()
 	{
-		var deltaTime = IsRunning
+		var deltaTime = IsAnimationEnabled
 			? frameCounter.NextFrame()
 			: TimeSpan.Zero;
 
 		Update(deltaTime);
 	}
 
-	private static void OnIsRunningPropertyChanged(BindableObject bindable, object? oldValue, object? newValue) =>
-		(bindable as SKAnimatedSurfaceView)?.UpdateIsRunning();
+	private static void OnIsAnimationEnabledPropertyChanged(BindableObject bindable, object? oldValue, object? newValue) =>
+		(bindable as SKAnimatedSurfaceView)?.UpdateIsAnimationEnabled();
 
 	private void OnLoaded(object? sender, EventArgs e)
 	{
-		UpdateIsRunning();
+		UpdateIsAnimationEnabled();
 	}
 
-	private void UpdateIsRunning()
+	private void UpdateIsAnimationEnabled()
 	{
 		if (!this.IsLoadedEx())
 			return;
 
 		frameCounter.Reset();
 
-		if (!IsRunning)
+		if (!IsAnimationEnabled)
 			return;
 
 		Dispatcher.StartTimer(
@@ -76,7 +79,7 @@ public class SKAnimatedSurfaceView : SKSurfaceView
 			{
 				Invalidate();
 
-				return IsRunning;
+				return IsAnimationEnabled;
 			});
 	}
 }


### PR DESCRIPTION
**Description of Change**

<!-- Describe your changes here.  -->

This PR renames the `IsRunning` property to `IsAnimationEnabled` to hopefully provide a more meaningful name to the consumer.

**Bugs Fixed**

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

- Related to issue #

**API Changes**

<!-- REPLACE THIS COMMENT
List all API changes here (or just put None), example:
 
-->

Changed:

 - `bool SKAnimatedSurfaceView.IsRunning => bool SKAnimatedSurfaceView.IsAnimationEnabled`

**Behavioral Changes**

Changed the default binding mode for the above property from `BindingMode.TwoWay` to `BindingMode.OneWay`. The old way caused an issue in testing plus the property is only intended to change whether the control is animating and therefore does not need to update the source.

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description) - I haven't work out how to test this part yet
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation
