### PR TITLE
Rename IsCompleted to IsRunning

### DIFF
--- a/docs/api/ui-forms/skconfettiview.md
+++ b/docs/api/ui-forms/skconfettiview.md
@@ -14,7 +14,7 @@ The main property of a confetti view is the `Systems` property:
 | :--------------------- | :---------------------------- | :---------- |
 | **Systems**            | `SKConfettiSystemCollection`  | The collection of [systems](#system) in the view. |
 | **IsAnimationEnabled** | `bool`                        | Determines whether the control will play the animation provided. |
-| **IsComplete**         | `bool`                        | A value that indicates whether all systems are complete. |
+| **IsRunning**          | `bool`                        | Determines whether the control is currently rendering confetti. |
 
 ## Parts
 
@@ -52,7 +52,7 @@ Every confetti view consists up one or more systems (`SKConfettiSystem`). Each s
 | **FadeOut**                   | `bool`                         | Whether or not the particle should fade out at the end of its life. |
 | **Lifetime**                  | `double`                       | The duration in seconds for how long the particle is allowed to live. |
 | **IsAnimationEnabled**        | `bool`                         | Controls whether the system is running or not. |
-| **IsComplete**                | `bool`                         | A value that indicates whether the system is complete and all systems and particles are also complete. |
+| **IsRunning**                 | `bool`                         | Determines whether the system is complete and all systems and particles are also complete. |
 
 # Emitter
 
@@ -63,7 +63,7 @@ Each system has an emitter instance that controls how the confetti particles are
 | **ParticleRate**  | `int`     | The number of particles to generate each second. |
 | **MaxParticles**  | `int`     | The maximum number of particles allowed by the emitter. A value of `-1` indicates no limit. |
 | **Duration**      | `double`  | The duration in seconds of how long the emitter runs for. A value of `0` indicates that all particles are emitted instantly. |
-| **IsComplete**    | `bool`    | A value that indicates whether the emitter has generated all the particles and they have all disappeared. |
+| **IsRunning**     | `bool`    | Determines whether the emitter has generated all the particles and they have all disappeared. |
 
 ## Helper Emitters
 

--- a/docs/api/ui-forms/sklottieview.md
+++ b/docs/api/ui-forms/sklottieview.md
@@ -18,7 +18,7 @@ There are several properties that can be used to control th animation playback:
 | **RepeatCount**        | `int`                  | The number of times to repeat the animation. Default is 0 (no repeat). |
 | **RepeatMode**         | `SKLottieRepeatMode`   | The way in which to repeat the animation. Default is `Restart`. |
 | **IsAnimationEnabled** | `bool`                 | Determines whether the control will play the animation provided. |
-| **IsComplete**         | `bool`                 | A value that indicates whether all systems are complete. |
+| **IsRunning**          | `bool`                 | Determines whether the control is currently rendering the animation. |
 
 ## Events
 

--- a/docs/api/ui-maui/skconfettiview.md
+++ b/docs/api/ui-maui/skconfettiview.md
@@ -14,7 +14,7 @@ The main property of a confetti view is the `Systems` property:
 | :--------------------- | :---------------------------- | :---------- |
 | **Systems**            | `SKConfettiSystemCollection`  | The collection of [systems](#system) in the view. |
 | **IsAnimationEnabled** | `bool`                        | Determines whether the control will play the animation provided. |
-| **IsComplete**         | `bool`                        | A value that indicates whether all systems are complete. |
+| **IsRunning**          | `bool`                        | Determines whether the control is currently rendering confetti. |
 
 ## Parts
 
@@ -52,7 +52,7 @@ Every confetti view consists up one or more systems (`SKConfettiSystem`). Each s
 | **FadeOut**                   | `bool`                         | Whether or not the particle should fade out at the end of its life. |
 | **Lifetime**                  | `double`                       | The duration in seconds for how long the particle is allowed to live. |
 | **IsAnimationEnabled**        | `bool`                         | Controls whether the system is running or not. |
-| **IsComplete**                | `bool`                         | A value that indicates whether the system is complete and all systems and particles are also complete. |
+| **IsRunning**                 | `bool`                         | Determines whether the system is complete and all systems and particles are also complete. |
 
 # Emitter
 
@@ -63,7 +63,8 @@ Each system has an emitter instance that controls how the confetti particles are
 | **ParticleRate**  | `int`     | The number of particles to generate each second. |
 | **MaxParticles**  | `int`     | The maximum number of particles allowed by the emitter. A value of `-1` indicates no limit. |
 | **Duration**      | `double`  | The duration in seconds of how long the emitter runs for. A value of `0` indicates that all particles are emitted instantly. |
-| **IsComplete**    | `bool`    | A value that indicates whether the emitter has generated all the particles and they have all disappeared. |
+| **IsRunning**     | `bool`    | Determines whether the control is currently rendering confetti. |
+| **IsRunning**     | `bool`    | Determines whether the emitter has generated all the particles and they have all disappeared. |
 
 ## Helper Emitters
 

--- a/docs/api/ui-maui/sklottieview.md
+++ b/docs/api/ui-maui/sklottieview.md
@@ -18,7 +18,7 @@ There are several properties that can be used to control th animation playback:
 | **RepeatCount**        | `int`                  | The number of times to repeat the animation. Default is 0 (no repeat). |
 | **RepeatMode**         | `SKLottieRepeatMode`   | The way in which to repeat the animation. Default is `Restart`. |
 | **IsAnimationEnabled** | `bool`                 | Determines whether the control will play the animation provided. |
-| **IsComplete**         | `bool`                 | A value that indicates whether all systems are complete. |
+| **IsRunning**          | `bool`                 | Determines whether the control is currently rendering the animation. |
 
 ## Events
 

--- a/samples/Forms/SkiaSharpDemo/Converters/InvertedBooleanConverter.cs
+++ b/samples/Forms/SkiaSharpDemo/Converters/InvertedBooleanConverter.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Globalization;
+using Xamarin.Forms;
+
+namespace SkiaSharpDemo.Converters
+{
+	public class InvertedBooleanConverter : IValueConverter
+	{
+		public object Convert(object value, Type targetType, object parameter, CultureInfo culture) =>
+			value switch
+			{
+				bool b => !b,
+				_ => throw new ArgumentException("Value was not a bool.", nameof(value)),
+			};
+
+		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Convert(value, targetType, parameter, culture);
+	}
+}

--- a/samples/Forms/SkiaSharpDemo/Demos/Confetti/ConfettiPage.xaml
+++ b/samples/Forms/SkiaSharpDemo/Demos/Confetti/ConfettiPage.xaml
@@ -1,9 +1,14 @@
 ﻿<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:controls="clr-namespace:SkiaSharp.Extended.UI.Controls;assembly=SkiaSharp.Extended.UI"
+             xmlns:converters="clr-namespace:SkiaSharpDemo.Converters"
              xmlns:views="clr-namespace:SkiaSharpDemo.Views"
              x:Class="SkiaSharpDemo.Demos.ConfettiPage"
              Title="Confetti">
+
+    <ContentPage.Resources>
+        <converters:InvertedBooleanConverter x:Key="InvertedBooleanConverter" />
+    </ContentPage.Resources>
 
     <Grid>
 
@@ -20,7 +25,7 @@
         <BoxView Color="Green" Opacity="0.5" CornerRadius="12"
                  WidthRequest="25" HeightRequest="24" Margin="24"
                  HorizontalOptions="End" VerticalOptions="Start"
-                 IsVisible="{Binding IsComplete, Source={Reference confettiView}}" />
+                 IsVisible="{Binding IsRunning, Source={Reference confettiView}, Converter={StaticResource InvertedBooleanConverter}}" />
 
         <views:BottomTabBar SelectedIndex="{Binding SelectedTab}" PagePadding="12,6">
             <views:BottomTabCollection>

--- a/samples/Forms/SkiaSharpDemo/Demos/Lottie/LottiePage.xaml
+++ b/samples/Forms/SkiaSharpDemo/Demos/Lottie/LottiePage.xaml
@@ -1,9 +1,13 @@
 ﻿<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:controls="clr-namespace:SkiaSharp.Extended.UI.Controls;assembly=SkiaSharp.Extended.UI"
-             xmlns:views="clr-namespace:SkiaSharpDemo.Views"
+             xmlns:converters="clr-namespace:SkiaSharpDemo.Converters"
              x:Class="SkiaSharpDemo.Demos.LottiePage"
              Title="Lottie">
+
+    <ContentPage.Resources>
+        <converters:InvertedBooleanConverter x:Key="InvertedBooleanConverter" />
+    </ContentPage.Resources>
 
     <Grid RowDefinitions="*,Auto">
 
@@ -16,7 +20,7 @@
         <BoxView Color="Green" Opacity="0.5" CornerRadius="12"
                  WidthRequest="25" HeightRequest="24" Margin="24"
                  HorizontalOptions="End" VerticalOptions="Start"
-                 IsVisible="{Binding IsComplete, Source={Reference lottieView}}" />
+                 IsVisible="{Binding IsRunning, Source={Reference confettiView}, Converter={StaticResource InvertedBooleanConverter}}" />
 
         <StackLayout Spacing="12" Padding="12" Grid.Row="1">
 

--- a/samples/Maui/SkiaSharpDemo/Converters/InvertedBoolConverter.cs
+++ b/samples/Maui/SkiaSharpDemo/Converters/InvertedBoolConverter.cs
@@ -1,0 +1,16 @@
+﻿using System.Globalization;
+
+namespace SkiaSharpDemo.Converters
+{
+	public class InvertedBooleanConverter : IValueConverter
+	{
+		public object Convert(object value, Type targetType, object parameter, CultureInfo culture) =>
+			value switch
+			{
+				bool b => !b,
+				_ => throw new ArgumentException("Value was not a bool.", nameof(value)),
+			};
+
+		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Convert(value, targetType, parameter, culture);
+	}
+}

--- a/samples/Maui/SkiaSharpDemo/Demos/Confetti/ConfettiPage.xaml
+++ b/samples/Maui/SkiaSharpDemo/Demos/Confetti/ConfettiPage.xaml
@@ -1,10 +1,15 @@
 ﻿<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:controls="clr-namespace:SkiaSharp.Extended.UI.Controls;assembly=SkiaSharp.Extended.UI"
+             xmlns:converters="clr-namespace:SkiaSharpDemo.Converters"
              xmlns:views="clr-namespace:SkiaSharpDemo.Views"
              x:Class="SkiaSharpDemo.Demos.ConfettiPage"
              Title="Confetti">
 
+    <ContentPage.Resources>
+        <converters:InvertedBooleanConverter x:Key="InvertedBooleanConverter" />
+    </ContentPage.Resources>
+    
     <Grid>
 
         <Label Text="{Binding Message}" FontSize="32" FontAttributes="Bold"
@@ -20,7 +25,7 @@
         <BoxView Color="Green" Opacity="0.5" CornerRadius="12"
                  WidthRequest="25" HeightRequest="24" Margin="24"
                  HorizontalOptions="End" VerticalOptions="Start"
-                 IsVisible="{Binding IsComplete, Source={Reference confettiView}}" />
+                 IsVisible="{Binding IsRunning, Source={Reference confettiView}, Converter={StaticResource InvertedBooleanConverter}}" />
 
         <views:BottomTabBar SelectedIndex="{Binding SelectedTab}" PagePadding="12,6">
             <views:BottomTabCollection>

--- a/samples/Maui/SkiaSharpDemo/Demos/Lottie/LottiePage.xaml
+++ b/samples/Maui/SkiaSharpDemo/Demos/Lottie/LottiePage.xaml
@@ -1,9 +1,14 @@
 ﻿<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:controls="clr-namespace:SkiaSharp.Extended.UI.Controls;assembly=SkiaSharp.Extended.UI"
+             xmlns:converters="clr-namespace:SkiaSharpDemo.Converters"
              xmlns:views="clr-namespace:SkiaSharpDemo.Views"
              x:Class="SkiaSharpDemo.Demos.LottiePage"
              Title="Lottie">
+
+    <ContentPage.Resources>
+        <converters:InvertedBooleanConverter x:Key="InvertedBooleanConverter" />
+    </ContentPage.Resources>
 
     <Grid RowDefinitions="*,Auto">
 
@@ -18,7 +23,7 @@
         <BoxView Color="Green" Opacity="0.5" CornerRadius="12"
                  WidthRequest="25" HeightRequest="24" Margin="24"
                  HorizontalOptions="End" VerticalOptions="Start"
-                 IsVisible="{Binding IsComplete, Source={Reference lottieView}}" />
+                 IsVisible="{Binding IsRunning, Source={Reference confettiView}, Converter={StaticResource InvertedBooleanConverter}}" />
 
         <VerticalStackLayout Spacing="12" Padding="12" Grid.Row="1">
 

--- a/source/SkiaSharp.Extended.UI/Controls/Confetti/SKConfettiEmitter.shared.cs
+++ b/source/SkiaSharp.Extended.UI/Controls/Confetti/SKConfettiEmitter.shared.cs
@@ -65,6 +65,9 @@ namespace SkiaSharp.Extended.UI.Controls
 			set => SetValue(DurationProperty, value);
 		}
 
+		/// <summary>
+		/// Gets a value indicating whether confetti is being emitted.
+		/// </summary>
 		public bool IsRunning
 		{
 			get => (bool)GetValue(IsRunningProperty);

--- a/source/SkiaSharp.Extended.UI/Controls/Confetti/SKConfettiEmitter.shared.cs
+++ b/source/SkiaSharp.Extended.UI/Controls/Confetti/SKConfettiEmitter.shared.cs
@@ -22,13 +22,14 @@ namespace SkiaSharp.Extended.UI.Controls
 			typeof(SKConfettiEmitter),
 			5.0);
 
-		private static readonly BindablePropertyKey IsCompletePropertyKey = BindableProperty.CreateReadOnly(
-			nameof(IsComplete),
+		private static readonly BindablePropertyKey IsRunningPropertyKey = BindableProperty.CreateReadOnly(
+			nameof(IsRunning),
 			typeof(bool),
 			typeof(SKConfettiEmitter),
-			false);
+			true,
+			defaultBindingMode: BindingMode.OneWayToSource);
 
-		public static readonly BindableProperty IsCompleteProperty = IsCompletePropertyKey.BindableProperty;
+		public static readonly BindableProperty IsRunningProperty = IsRunningPropertyKey.BindableProperty;
 
 		private int totalParticles = 0;
 		private double totalDuration = 0;
@@ -64,17 +65,17 @@ namespace SkiaSharp.Extended.UI.Controls
 			set => SetValue(DurationProperty, value);
 		}
 
-		public bool IsComplete
+		public bool IsRunning
 		{
-			get => (bool)GetValue(IsCompleteProperty);
-			private set => SetValue(IsCompletePropertyKey, value);
+			get => (bool)GetValue(IsRunningProperty);
+			private set => SetValue(IsRunningPropertyKey, value);
 		}
 
 		public event Action<int>? ParticlesCreated;
 
 		public void Update(TimeSpan deltaTime)
 		{
-			if (IsComplete)
+			if (!IsRunning)
 				return;
 
 			var prevDuration = totalDuration;
@@ -96,10 +97,7 @@ namespace SkiaSharp.Extended.UI.Controls
 
 			ParticlesCreated?.Invoke(particles);
 
-			IsComplete =
-				Duration == 0 || // burst mode
-				(MaxParticles > 0 && totalParticles >= MaxParticles) || // reached the max particles
-				(Duration > 0 && totalDuration >= Duration); // reached the max duration
+			UpdateIsRunning();
 		}
 
 		public static SKConfettiEmitter Burst(int particles) =>
@@ -113,5 +111,13 @@ namespace SkiaSharp.Extended.UI.Controls
 
 		public static SKConfettiEmitter Infinite(int particleRate, int maxParticles) =>
 			new SKConfettiEmitter(particleRate, maxParticles, -1);
+
+		private void UpdateIsRunning()
+		{
+			IsRunning =
+				Duration != 0 && // burst mode
+				(MaxParticles > 0 && totalParticles < MaxParticles) || // reached the max particles
+				(Duration > 0 && totalDuration < Duration); // reached the max duration
+		}
 	}
 }

--- a/source/SkiaSharp.Extended.UI/Controls/Confetti/SKConfettiParticle.shared.cs
+++ b/source/SkiaSharp.Extended.UI/Controls/Confetti/SKConfettiParticle.shared.cs
@@ -52,11 +52,11 @@ internal class SKConfettiParticle
 
 	public SKRect Bounds { get; private set; }
 
-	public bool IsComplete { get; private set; }
+	public bool IsRunning { get; private set; } = true;
 
 	public void Draw(SKCanvas canvas)
 	{
-		if (IsComplete || Shape == null)
+		if (!IsRunning || Shape == null)
 			return;
 
 		canvas.Save();
@@ -81,7 +81,7 @@ internal class SKConfettiParticle
 
 	public void ApplyForce(SKPoint force, TimeSpan deltaTime)
 	{
-		if (IsComplete)
+		if (!IsRunning)
 			return;
 
 		var secs = (float)deltaTime.TotalSeconds;
@@ -119,11 +119,11 @@ internal class SKConfettiParticle
 				var c = Color;
 				var alpha = c.Alpha - secs;
 				Color = c.WithAlpha(alpha);
-				IsComplete = alpha <= 0;
+				IsRunning = alpha > 0;
 			}
 			else
 			{
-				IsComplete = true;
+				IsRunning = false;
 			}
 		}
 

--- a/source/SkiaSharp.Extended.UI/Controls/Confetti/SKConfettiSystem.shared.cs
+++ b/source/SkiaSharp.Extended.UI/Controls/Confetti/SKConfettiSystem.shared.cs
@@ -97,13 +97,14 @@ public class SKConfettiSystem : BindableObject
 		typeof(SKConfettiSystem),
 		new Point(0, 9.81f));
 
-	private static readonly BindablePropertyKey IsCompletePropertyKey = BindableProperty.CreateReadOnly(
-		nameof(IsComplete),
+	private static readonly BindablePropertyKey IsRunningPropertyKey = BindableProperty.CreateReadOnly(
+		nameof(IsRunning),
 		typeof(bool),
 		typeof(SKConfettiSystem),
-		false);
+		true,
+		defaultBindingMode: BindingMode.OneWayToSource);
 
-	public static readonly BindableProperty IsCompleteProperty = IsCompletePropertyKey.BindableProperty;
+	public static readonly BindableProperty IsRunningProperty = IsRunningPropertyKey.BindableProperty;
 
 	public static readonly BindableProperty IsAnimationEnabledProperty = BindableProperty.Create(
 		nameof(IsAnimationEnabled),
@@ -221,10 +222,10 @@ public class SKConfettiSystem : BindableObject
 		set => SetValue(GravityProperty, value);
 	}
 
-	public bool IsComplete
+	public bool IsRunning
 	{
-		get => (bool)GetValue(IsCompleteProperty);
-		private set => SetValue(IsCompletePropertyKey, value);
+		get => (bool)GetValue(IsRunningProperty);
+		private set => SetValue(IsRunningPropertyKey, value);
 	}
 
 	internal int ParticleCount => particles.Count;
@@ -243,7 +244,7 @@ public class SKConfettiSystem : BindableObject
 
 			particle.ApplyForce(g, deltaTime);
 
-			if (particle.IsComplete || !lastViewBounds.IntersectsWith(particle.Bounds))
+			if (!particle.IsRunning || !lastViewBounds.IntersectsWith(particle.Bounds))
 			{
 				particles.RemoveAt(i);
 				removed = true;
@@ -251,7 +252,7 @@ public class SKConfettiSystem : BindableObject
 		}
 
 		if (removed)
-			UpdateIsComplete();
+			UpdateIsRunning();
 	}
 
 	public void Draw(SKCanvas canvas)
@@ -310,7 +311,7 @@ public class SKConfettiSystem : BindableObject
 			particles.Add(particle);
 		}
 
-		UpdateIsComplete();
+		UpdateIsRunning();
 
 		Point GetNewLocation()
 		{
@@ -354,7 +355,7 @@ public class SKConfettiSystem : BindableObject
 			if (newValue is SKConfettiEmitter newE)
 				newE.ParticlesCreated += system.OnCreateParticle;
 
-			system.UpdateIsComplete();
+			system.UpdateIsRunning();
 		}
 	}
 
@@ -362,14 +363,14 @@ public class SKConfettiSystem : BindableObject
 	{
 		if (bindable is SKConfettiSystem system)
 		{
-			system.UpdateIsComplete();
+			system.UpdateIsRunning();
 		}
 	}
 
-	private bool UpdateIsComplete() =>
-		IsComplete =
-			particles.Count == 0 &&
-			Emitter?.IsComplete != false &&
+	private bool UpdateIsRunning() =>
+		IsRunning =
+			particles.Count != 0 &&
+			Emitter?.IsRunning == true &&
 			IsAnimationEnabled;
 
 	private static SKConfettiColorCollection CreateDefaultColors() =>

--- a/source/SkiaSharp.Extended.UI/Controls/Confetti/SKConfettiView.shared.cs
+++ b/source/SkiaSharp.Extended.UI/Controls/Confetti/SKConfettiView.shared.cs
@@ -4,13 +4,14 @@ namespace SkiaSharp.Extended.UI.Controls;
 
 public class SKConfettiView : SKAnimatedSurfaceView
 {
-	private static readonly BindablePropertyKey IsCompletePropertyKey = BindableProperty.CreateReadOnly(
-		nameof(IsComplete),
+	private static readonly BindablePropertyKey IsRunningPropertyKey = BindableProperty.CreateReadOnly(
+		nameof(IsRunning),
 		typeof(bool),
 		typeof(SKConfettiView),
-		false);
+		false,
+		defaultBindingMode: BindingMode.OneWayToSource);
 
-	public static readonly BindableProperty IsCompleteProperty = IsCompletePropertyKey.BindableProperty;
+	public static readonly BindableProperty IsRunningProperty = IsRunningPropertyKey.BindableProperty;
 
 	public static readonly BindableProperty SystemsProperty = BindableProperty.Create(
 		nameof(Systems),
@@ -36,10 +37,10 @@ public class SKConfettiView : SKAnimatedSurfaceView
 		OnSystemsPropertyChanged(this, null, Systems);
 	}
 
-	public bool IsComplete
+	public bool IsRunning
 	{
-		get => (bool)GetValue(IsCompleteProperty);
-		private set => SetValue(IsCompletePropertyKey, value);
+		get => (bool)GetValue(IsRunningProperty);
+		private set => SetValue(IsRunningPropertyKey, value);
 	}
 
 	public SKConfettiSystemCollection? Systems
@@ -58,7 +59,7 @@ public class SKConfettiView : SKAnimatedSurfaceView
 			var system = Systems[i];
 			system.Update(deltaTime);
 
-			if (system.IsComplete)
+			if (!system.IsRunning)
 				Systems.RemoveAt(i);
 		}
 	}
@@ -106,7 +107,7 @@ public class SKConfettiView : SKAnimatedSurfaceView
 			Invalidate();
 		}
 
-		UpdateIsComplete();
+		UpdateIsRunning();
 	}
 
 	private void OnIsAnimationEnabledPropertyChanged()
@@ -131,28 +132,28 @@ public class SKConfettiView : SKAnimatedSurfaceView
 		if (newValue is SKConfettiSystemCollection newCollection)
 			newCollection.CollectionChanged += cv.OnSystemsCollectionChanged;
 
-		cv.UpdateIsComplete();
+		cv.UpdateIsRunning();
 	}
 
-	private void UpdateIsComplete()
+	private void UpdateIsRunning()
 	{
 		if (Systems is null || Systems.Count == 0)
 		{
-			IsComplete = true;
+			IsRunning = false;
 			return;
 		}
 
-		var isComplete = false;
+		var isRunning = true;
 		foreach (var system in Systems)
 		{
-			if (system.IsComplete)
+			if (!system.IsRunning)
 			{
-				isComplete = true;
+				isRunning = false;
 				break;
 			}
 		}
 
-		IsComplete = isComplete;
+		IsRunning = isRunning;
 	}
 
 	private static SKConfettiSystemCollection CreateDefaultSystems() =>

--- a/source/SkiaSharp.Extended.UI/Controls/Confetti/SKConfettiView.shared.cs
+++ b/source/SkiaSharp.Extended.UI/Controls/Confetti/SKConfettiView.shared.cs
@@ -37,6 +37,13 @@ public class SKConfettiView : SKAnimatedSurfaceView
 		OnSystemsPropertyChanged(this, null, Systems);
 	}
 
+	/// <summary>
+	/// Gets a value indicating whether the confetti emission is running.
+	/// </summary>
+	/// <remarks>
+	/// NOTE this is a <see cref="BindingMode.OneWayToSource"/> property, if you wish to control whether the animation is
+	/// enabled refer to the <see cref="SKAnimatedSurfaceView.IsAnimationEnabled"/> property.
+	/// </remarks>
 	public bool IsRunning
 	{
 		get => (bool)GetValue(IsRunningProperty);

--- a/source/SkiaSharp.Extended.UI/Controls/Lottie/SKLottieView.shared.cs
+++ b/source/SkiaSharp.Extended.UI/Controls/Lottie/SKLottieView.shared.cs
@@ -26,13 +26,14 @@ public class SKLottieView : SKAnimatedSurfaceView
 		BindingMode.TwoWay,
 		propertyChanged: OnProgressDurationPropertyChanged);
 
-	private static readonly BindablePropertyKey IsCompletePropertyKey = BindableProperty.CreateReadOnly(
-		nameof(IsComplete),
+	private static readonly BindablePropertyKey IsRunningPropertyKey = BindableProperty.CreateReadOnly(
+		nameof(IsRunning),
 		typeof(bool),
 		typeof(SKLottieView),
-		false);
+		false,
+		defaultBindingMode: BindingMode.OneWayToSource);
 
-	public static readonly BindableProperty IsCompleteProperty = IsCompletePropertyKey.BindableProperty;
+	public static readonly BindableProperty IsRunningProperty = IsRunningPropertyKey.BindableProperty;
 
 	public static readonly BindableProperty RepeatCountProperty = BindableProperty.Create(
 		nameof(RepeatCount),
@@ -75,10 +76,10 @@ public class SKLottieView : SKAnimatedSurfaceView
 		set => SetValue(ProgressProperty, value);
 	}
 
-	public bool IsComplete
+	public bool IsRunning
 	{
-		get => (bool)GetValue(IsCompleteProperty);
-		private set => SetValue(IsCompletePropertyKey, value);
+		get => (bool)GetValue(IsRunningProperty);
+		private set => SetValue(IsRunningPropertyKey, value);
 	}
 
 	public int RepeatCount
@@ -134,7 +135,7 @@ public class SKLottieView : SKAnimatedSurfaceView
 	{
 		if (animation is null)
 		{
-			IsComplete = true;
+			IsRunning = false;
 			return;
 		}
 
@@ -158,7 +159,7 @@ public class SKLottieView : SKAnimatedSurfaceView
 			// we need to reverse to finish the run
 			playForwards = !playForwards;
 
-			IsComplete = false;
+			IsRunning = true;
 		}
 		else
 		{
@@ -186,9 +187,9 @@ public class SKLottieView : SKAnimatedSurfaceView
 					playForwards = !playForwards;
 			}
 
-			IsComplete =
-				isFinishedRun &&
-				repeatsCompleted >= totalRepeatCount;
+			IsRunning =
+				!isFinishedRun &&
+				repeatsCompleted < totalRepeatCount;
 		}
 
 		if (!IsAnimationEnabled)

--- a/tests/SkiaSharp.Extended.UI.Tests/Controls/Confetti/SKConfettiEmitterTest.cs
+++ b/tests/SkiaSharp.Extended.UI.Tests/Controls/Confetti/SKConfettiEmitterTest.cs
@@ -28,13 +28,13 @@ namespace SkiaSharp.Extended.UI.Controls.Tests
 
 			Assert.Equal(100, totalCreated);
 			Assert.Equal(1, totalInvoke);
-			Assert.True(emitter.IsComplete);
+			Assert.False(emitter.IsRunning);
 
 			emitter.Update(dt);
 
 			Assert.Equal(100, totalCreated);
 			Assert.Equal(1, totalInvoke);
-			Assert.True(emitter.IsComplete);
+			Assert.False(emitter.IsRunning);
 		}
 
 		[Theory]
@@ -60,13 +60,13 @@ namespace SkiaSharp.Extended.UI.Controls.Tests
 
 			Assert.Equal(50, totalCreated);
 			Assert.Equal(1, totalInvoke);
-			Assert.True(emitter.IsComplete);
+			Assert.False(emitter.IsRunning);
 
 			emitter.Update(dt);
 
 			Assert.Equal(50, totalCreated);
 			Assert.Equal(1, totalInvoke);
-			Assert.True(emitter.IsComplete);
+			Assert.False(emitter.IsRunning);
 		}
 
 		[Theory]
@@ -92,22 +92,22 @@ namespace SkiaSharp.Extended.UI.Controls.Tests
 
 			Assert.Equal(100, totalCreated);
 			Assert.Equal(1, totalInvoke);
-			Assert.True(emitter.IsComplete);
+			Assert.False(emitter.IsRunning);
 
 			emitter.Update(dt);
 
 			Assert.Equal(100, totalCreated);
 			Assert.Equal(1, totalInvoke);
-			Assert.True(emitter.IsComplete);
+			Assert.False(emitter.IsRunning);
 		}
 
 		[Theory]
-		[InlineData(0, 0, 0, false, false)]
-		[InlineData(10, 1, 2, false, false)]
-		[InlineData(500, 50, 100, false, true)]
-		[InlineData(1000, 100, 100, true, true)]
-		[InlineData(10000, 100, 100, true, true)]
-		public void ParticleRateNoMaxOneMin(int milliseconds, int expectedCreated, int expectedCreated2, bool complete, bool complete2)
+		[InlineData(0, 0, 0, true, true)]
+		[InlineData(10, 1, 2, true, true)]
+		[InlineData(500, 50, 100, true, false)]
+		[InlineData(1000, 100, 100, false, false)]
+		[InlineData(10000, 100, 100, false, false)]
+		public void ParticleRateNoMaxOneMin(int milliseconds, int expectedCreated, int expectedCreated2, bool isRunning, bool isRunning2)
 		{
 			var dt = TimeSpan.FromMilliseconds(milliseconds);
 
@@ -125,16 +125,16 @@ namespace SkiaSharp.Extended.UI.Controls.Tests
 
 			Assert.Equal(expectedCreated, totalCreated);
 			Assert.Equal(1, totalInvoke);
-			Assert.Equal(complete, emitter.IsComplete);
+			Assert.Equal(isRunning, emitter.IsRunning);
 
 			emitter.Update(dt);
 
 			Assert.Equal(expectedCreated2, totalCreated);
-			if (complete)
+			if (!isRunning)
 				Assert.Equal(1, totalInvoke);
 			else
 				Assert.Equal(2, totalInvoke);
-			Assert.Equal(complete2, emitter.IsComplete);
+			Assert.Equal(isRunning2, emitter.IsRunning);
 		}
 	}
 }

--- a/tests/SkiaSharp.Extended.UI.Tests/Controls/Confetti/SKConfettiSystemTest.cs
+++ b/tests/SkiaSharp.Extended.UI.Tests/Controls/Confetti/SKConfettiSystemTest.cs
@@ -1,27 +1,26 @@
-﻿using System;
-using Xunit;
+﻿using Xunit;
 
 namespace SkiaSharp.Extended.UI.Controls.Tests
 {
 	public class SKConfettiSystemTest
 	{
 		[Fact]
-		public void DefaultIsNotComplete()
+		public void DefaultIsNotRunning()
 		{
 			var system = new SKConfettiSystem();
 
 			Assert.True(system.IsAnimationEnabled);
-			Assert.False(system.IsComplete);
+			Assert.False(system.IsRunning);
 		}
 
 		[Fact]
-		public void NotRunningIsNotComplete()
+		public void NotRunningIsReallyNotRunning()
 		{
 			var system = new SKConfettiSystem();
 			system.IsAnimationEnabled = false;
 
 			Assert.False(system.IsAnimationEnabled);
-			Assert.False(system.IsComplete);
+			Assert.False(system.IsRunning);
 		}
 	}
 }


### PR DESCRIPTION
**Description of Change**

<!-- Describe your changes here.  -->
Renamed the `IsComplete` property to `IsRunning`.

**Bugs Fixed**

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

- Related to issue #

**API Changes**

<!-- REPLACE THIS COMMENT
List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `bool SKConfettiView.IsComplete => bool SKConfettiView.IsRunning`
 - `bool SKLottieView.IsComplete => bool SKLottieView.IsRunning`
 
-->

**Behavioral Changes**

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

Inversion of the value to match the change of name.
The `IsRunning` property now has a default binding mode of `BindingMode.OneWayToSource` as it is used to bring information out of the control and drive values in.

**PR Checklist**

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation
