### PR TITLE
Change default binding mode of readonly properties

### DIFF
--- a/source/SkiaSharp.Extended.UI/Controls/Confetti/SKConfettiEmitter.shared.cs
+++ b/source/SkiaSharp.Extended.UI/Controls/Confetti/SKConfettiEmitter.shared.cs
@@ -26,7 +26,8 @@ namespace SkiaSharp.Extended.UI.Controls
 			nameof(IsComplete),
 			typeof(bool),
 			typeof(SKConfettiEmitter),
-			false);
+			false,
+			defaultBindingMode: BindingMode.OneWayToSource);
 
 		public static readonly BindableProperty IsCompleteProperty = IsCompletePropertyKey.BindableProperty;
 

--- a/source/SkiaSharp.Extended.UI/Controls/Confetti/SKConfettiSystem.shared.cs
+++ b/source/SkiaSharp.Extended.UI/Controls/Confetti/SKConfettiSystem.shared.cs
@@ -101,7 +101,8 @@ public class SKConfettiSystem : BindableObject
 		nameof(IsComplete),
 		typeof(bool),
 		typeof(SKConfettiSystem),
-		false);
+		false,
+		defaultBindingMode: BindingMode.OneWayToSource);
 
 	public static readonly BindableProperty IsCompleteProperty = IsCompletePropertyKey.BindableProperty;
 

--- a/source/SkiaSharp.Extended.UI/Controls/Confetti/SKConfettiView.shared.cs
+++ b/source/SkiaSharp.Extended.UI/Controls/Confetti/SKConfettiView.shared.cs
@@ -8,7 +8,8 @@ public class SKConfettiView : SKAnimatedSurfaceView
 		nameof(IsComplete),
 		typeof(bool),
 		typeof(SKConfettiView),
-		false);
+		false,
+		defaultBindingMode: BindingMode.OneWayToSource);
 
 	public static readonly BindableProperty IsCompleteProperty = IsCompletePropertyKey.BindableProperty;
 

--- a/source/SkiaSharp.Extended.UI/Controls/Lottie/SKLottieView.shared.cs
+++ b/source/SkiaSharp.Extended.UI/Controls/Lottie/SKLottieView.shared.cs
@@ -14,6 +14,7 @@ public class SKLottieView : SKAnimatedSurfaceView
 		typeof(TimeSpan),
 		typeof(SKLottieView),
 		TimeSpan.Zero,
+		defaultBindingMode: BindingMode.OneWayToSource,
 		propertyChanged: OnProgressDurationPropertyChanged);
 
 	public static readonly BindableProperty DurationProperty = DurationPropertyKey.BindableProperty;
@@ -30,7 +31,8 @@ public class SKLottieView : SKAnimatedSurfaceView
 		nameof(IsComplete),
 		typeof(bool),
 		typeof(SKLottieView),
-		false);
+		false,
+		defaultBindingMode: BindingMode.OneWayToSource);
 
 	public static readonly BindableProperty IsCompleteProperty = IsCompletePropertyKey.BindableProperty;
 

--- a/tests/SkiaSharp.Extended.UI.Tests/Controls/Confetti/SKConfettiSystemTest.cs
+++ b/tests/SkiaSharp.Extended.UI.Tests/Controls/Confetti/SKConfettiSystemTest.cs
@@ -15,7 +15,7 @@ namespace SkiaSharp.Extended.UI.Controls.Tests
 		}
 
 		[Fact]
-		public void NotRunningIsNotComplete()
+		public void NotEnabledIsStillNotComplete()
 		{
 			var system = new SKConfettiSystem();
 			system.IsAnimationEnabled = false;

--- a/tests/SkiaSharp.Extended.UI.Tests/Controls/Lottie/SKLottieViewTest.cs
+++ b/tests/SkiaSharp.Extended.UI.Tests/Controls/Lottie/SKLottieViewTest.cs
@@ -18,6 +18,7 @@ public class SKLottieViewTest
 		// test
 		Assert.Equal(TimeSpan.Zero, lottie.Progress);
 		Assert.Equal(TimeSpan.FromSeconds(2.3666665), lottie.Duration);
+		Assert.False(lottie.IsComplete);
 	}
 
 	[Fact]
@@ -36,6 +37,7 @@ public class SKLottieViewTest
 
 		// test
 		Assert.Equal(TimeSpan.Zero, lottie.Progress);
+		Assert.False(lottie.IsComplete);
 	}
 
 	[Fact]
@@ -51,6 +53,7 @@ public class SKLottieViewTest
 
 		// test
 		Assert.Equal(TimeSpan.FromSeconds(1), lottie.Progress);
+		Assert.False(lottie.IsComplete);
 	}
 
 	[Fact]
@@ -64,14 +67,17 @@ public class SKLottieViewTest
 		// update & test
 		lottie.CallUpdate(TimeSpan.FromSeconds(1));
 		Assert.Equal(TimeSpan.FromSeconds(1), lottie.Progress);
+		Assert.False(lottie.IsComplete);
 
 		// update & test
 		lottie.CallUpdate(TimeSpan.FromSeconds(1));
 		Assert.Equal(TimeSpan.FromSeconds(2), lottie.Progress);
+		Assert.False(lottie.IsComplete);
 
 		// update & test
 		lottie.CallUpdate(TimeSpan.FromSeconds(1));
 		Assert.Equal(TimeSpan.FromSeconds(2.3666665), lottie.Progress);
+		Assert.True(lottie.IsComplete);
 	}
 
 	[Fact]
@@ -87,6 +93,7 @@ public class SKLottieViewTest
 
 		// test
 		Assert.Equal(TimeSpan.FromSeconds(2.3666665), lottie.Progress);
+		Assert.True(lottie.IsComplete);
 	}
 
 	[Fact]
@@ -102,6 +109,7 @@ public class SKLottieViewTest
 
 		// test
 		Assert.Equal(TimeSpan.Zero, lottie.Progress);
+		Assert.False(lottie.IsComplete);
 	}
 
 	[Fact]
@@ -119,6 +127,7 @@ public class SKLottieViewTest
 
 		// test
 		Assert.Equal(TimeSpan.FromSeconds(1), lottie.Progress);
+		Assert.False(lottie.IsComplete);
 	}
 
 	[Theory]
@@ -149,23 +158,24 @@ public class SKLottieViewTest
 
 		// test
 		Assert.Equal(TimeSpan.FromSeconds(progress), lottie.Progress);
+		Assert.False(lottie.IsComplete);
 	}
 
 	[Theory]
-	[InlineData(SKLottieRepeatMode.Restart, 1, 1)]
-	[InlineData(SKLottieRepeatMode.Restart, 2, 2)]
-	[InlineData(SKLottieRepeatMode.Restart, 3, 2.3666665)]
-	[InlineData(SKLottieRepeatMode.Restart, 4, 2.3666665)]
-	[InlineData(SKLottieRepeatMode.Restart, 5, 2.3666665)]
-	[InlineData(SKLottieRepeatMode.Reverse, 1, 1)]
-	[InlineData(SKLottieRepeatMode.Reverse, 2, 2)]
-	[InlineData(SKLottieRepeatMode.Reverse, 3, 2.3666665)]
-	[InlineData(SKLottieRepeatMode.Reverse, 4, 1.3666665)]
-	[InlineData(SKLottieRepeatMode.Reverse, 5, 0.3666665)]
-	[InlineData(SKLottieRepeatMode.Reverse, 6, 0)]
-	[InlineData(SKLottieRepeatMode.Reverse, 7, 0)]
-	[InlineData(SKLottieRepeatMode.Reverse, 8, 0)]
-	public async Task ReachingTheEndAndThenMoreWithRepeatModeButZeroCount(SKLottieRepeatMode repeatMode, int steps, double progress)
+	[InlineData(SKLottieRepeatMode.Restart, 1, 1, false)]
+	[InlineData(SKLottieRepeatMode.Restart, 2, 2, false)]
+	[InlineData(SKLottieRepeatMode.Restart, 3, 2.3666665, true)]
+	[InlineData(SKLottieRepeatMode.Restart, 4, 2.3666665, true)]
+	[InlineData(SKLottieRepeatMode.Restart, 5, 2.3666665, true)]
+	[InlineData(SKLottieRepeatMode.Reverse, 1, 1, false)]
+	[InlineData(SKLottieRepeatMode.Reverse, 2, 2, false)]
+	[InlineData(SKLottieRepeatMode.Reverse, 3, 2.3666665, false)]
+	[InlineData(SKLottieRepeatMode.Reverse, 4, 1.3666665, false)]
+	[InlineData(SKLottieRepeatMode.Reverse, 5, 0.3666665, false)]
+	[InlineData(SKLottieRepeatMode.Reverse, 6, 0, true)]
+	[InlineData(SKLottieRepeatMode.Reverse, 7, 0, true)]
+	[InlineData(SKLottieRepeatMode.Reverse, 8, 0, true)]
+	public async Task ReachingTheEndAndThenMoreWithRepeatModeButZeroCount(SKLottieRepeatMode repeatMode, int steps, double progress, bool isComplete)
 	{
 		// create
 		var source = new SKFileLottieImageSource { File = TrophyJson };
@@ -178,5 +188,6 @@ public class SKLottieViewTest
 
 		// test
 		Assert.Equal(TimeSpan.FromSeconds(progress), lottie.Progress);
+		Assert.Equal(isComplete, lottie.IsComplete);
 	}
 }


### PR DESCRIPTION
**Description of Change**

No use having the default binding go from the VM to the property since the property is readonly and cannot change from the outside.

**Bugs Fixed**

None.

**API Changes**
None.

**Behavioral Changes**
None.

**PR Checklist**

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation
