### PR TITLE
Make some lottie image source members public

### DIFF
--- a/source/SkiaSharp.Extended.UI/Controls/Lottie/SKFileLottieImageSource.shared.cs
+++ b/source/SkiaSharp.Extended.UI/Controls/Lottie/SKFileLottieImageSource.shared.cs
@@ -2,7 +2,7 @@
 
 public class SKFileLottieImageSource : SKLottieImageSource
 {
-	public static BindableProperty FileProperty = BindableProperty.Create(
+	public static readonly BindableProperty FileProperty = BindableProperty.Create(
 		nameof(File), typeof(string), typeof(SKFileLottieImageSource),
 		propertyChanged: OnSourceChanged);
 
@@ -15,7 +15,7 @@ public class SKFileLottieImageSource : SKLottieImageSource
 	public override bool IsEmpty =>
 		string.IsNullOrEmpty(File);
 
-	internal override async Task<Skottie.Animation?> LoadAnimationAsync(CancellationToken cancellationToken = default)
+	public override async Task<Skottie.Animation?> LoadAnimationAsync(CancellationToken cancellationToken = default)
 	{
 		if (IsEmpty || string.IsNullOrEmpty(File))
 			return null;

--- a/source/SkiaSharp.Extended.UI/Controls/Lottie/SKLottieImageSource.shared.cs
+++ b/source/SkiaSharp.Extended.UI/Controls/Lottie/SKLottieImageSource.shared.cs
@@ -1,28 +1,33 @@
 ﻿namespace SkiaSharp.Extended.UI.Controls;
 
 [TypeConverter(typeof(Converters.SKLottieImageSourceConverter))]
-public class SKLottieImageSource : Element
+public abstract class SKLottieImageSource : Element
 {
 	private readonly WeakEventManager weakEventManager = new();
 
 	public virtual bool IsEmpty => true;
 
-	internal virtual Task<Skottie.Animation?> LoadAnimationAsync(CancellationToken cancellationToken = default) =>
-		throw new NotImplementedException();
+	public abstract Task<Skottie.Animation?> LoadAnimationAsync(CancellationToken cancellationToken = default);
 
-	internal static object FromUri(Uri uri) =>
+	public static object FromUri(Uri uri) =>
 		new SKUriLottieImageSource { Uri = uri };
 
-	internal static object FromFile(string file) =>
+	public static object FromFile(string file) =>
 		new SKFileLottieImageSource { File = file };
 
-	internal event EventHandler SourceChanged
+	public static object FromStream(Func<CancellationToken, Task<Stream?>> getter) =>
+		new SKStreamLottieImageSource { Stream = getter };
+
+	public static object FromStream(Stream stream) =>
+		FromStream(token => Task.FromResult<Stream?>(stream));
+
+	public event EventHandler SourceChanged
 	{
 		add => weakEventManager.AddEventHandler(value);
 		remove => weakEventManager.RemoveEventHandler(value);
 	}
 
-	internal static void OnSourceChanged(BindableObject bindable, object oldValue, object newValue)
+	protected static void OnSourceChanged(BindableObject bindable, object oldValue, object newValue)
 	{
 		if (bindable is SKLottieImageSource source)
 			source.weakEventManager.HandleEvent(source, EventArgs.Empty, nameof(SourceChanged));

--- a/source/SkiaSharp.Extended.UI/Controls/Lottie/SKStreamLottieImageSource.shared.cs
+++ b/source/SkiaSharp.Extended.UI/Controls/Lottie/SKStreamLottieImageSource.shared.cs
@@ -2,7 +2,7 @@
 
 public class SKStreamLottieImageSource : SKLottieImageSource
 {
-	public static BindableProperty StreamProperty = BindableProperty.Create(
+	public static readonly BindableProperty StreamProperty = BindableProperty.Create(
 		nameof(Stream), typeof(Func<CancellationToken, Task<Stream?>>), typeof(SKStreamLottieImageSource),
 		propertyChanged: OnSourceChanged);
 
@@ -14,7 +14,7 @@ public class SKStreamLottieImageSource : SKLottieImageSource
 
 	public override bool IsEmpty => Stream is null;
 
-	internal override async Task<Skottie.Animation?> LoadAnimationAsync(CancellationToken cancellationToken = default)
+	public override async Task<Skottie.Animation?> LoadAnimationAsync(CancellationToken cancellationToken = default)
 	{
 		if (IsEmpty || Stream is null)
 			return null;

--- a/source/SkiaSharp.Extended.UI/Controls/Lottie/SKUriLottieImageSource.shared.cs
+++ b/source/SkiaSharp.Extended.UI/Controls/Lottie/SKUriLottieImageSource.shared.cs
@@ -2,7 +2,7 @@
 
 public class SKUriLottieImageSource : SKLottieImageSource
 {
-	public static BindableProperty UriProperty = BindableProperty.Create(
+	public static readonly BindableProperty UriProperty = BindableProperty.Create(
 		nameof(Uri), typeof(Uri), typeof(SKUriLottieImageSource),
 		propertyChanged: OnSourceChanged);
 
@@ -14,7 +14,7 @@ public class SKUriLottieImageSource : SKLottieImageSource
 
 	public override bool IsEmpty => Uri is null;
 
-	internal override async Task<Skottie.Animation?> LoadAnimationAsync(CancellationToken cancellationToken = default)
+	public override async Task<Skottie.Animation?> LoadAnimationAsync(CancellationToken cancellationToken = default)
 	{
 		if (IsEmpty || Uri is null)
 			return null;


### PR DESCRIPTION
**Description of Change**

Some of the lottie image source APIs are incorrect or internal. The incorrect ones are fixed, and the internal ones are now public. I was unsure at the time on what I wanted so did not spend too much time on the API and made it all internal.

**Bugs Fixed**

- Fixes #170

