### PR TITLE
Update Dependencies and Android Target Version

### DIFF
--- a/samples/Forms/SkiaSharpDemo.Android/SkiaSharpDemo.Android.csproj
+++ b/samples/Forms/SkiaSharpDemo.Android/SkiaSharpDemo.Android.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -16,7 +16,7 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
-    <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v13.0</TargetFrameworkVersion>
     <AndroidSupportedAbis>armeabi-v7a;x86;arm64-v8a;x86_64</AndroidSupportedAbis>
     <AndroidUseIntermediateDesignerFile>true</AndroidUseIntermediateDesignerFile>
   </PropertyGroup>
@@ -52,13 +52,13 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="HarfBuzzSharp" Version="2.8.2.4" />
-    <PackageReference Include="SkiaSharp" Version="2.88.4" />
-    <PackageReference Include="SkiaSharp.Views" Version="2.88.4" />
-    <PackageReference Include="SkiaSharp.Views.Forms" Version="2.88.4" />
-    <PackageReference Include="Xamarin.Essentials" Version="1.6.1" />
-    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2401" />
-    <PackageReference Include="Topten.RichTextKit" Version="0.4.137" />
+    <PackageReference Include="HarfBuzzSharp" Version="2.8.2.5" />
+    <PackageReference Include="SkiaSharp" Version="2.88.5" />
+    <PackageReference Include="SkiaSharp.Views" Version="2.88.5" />
+    <PackageReference Include="SkiaSharp.Views.Forms" Version="2.88.5" />
+    <PackageReference Include="Xamarin.Essentials" Version="1.8.0" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2612" />
+    <PackageReference Include="Topten.RichTextKit" Version="0.4.166" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\source\SkiaSharp.Extended.UI.Forms\SkiaSharp.Extended.UI.Forms.csproj">

--- a/samples/Forms/SkiaSharpDemo.UWP/SkiaSharpDemo.UWP.csproj
+++ b/samples/Forms/SkiaSharpDemo.UWP/SkiaSharpDemo.UWP.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -119,13 +119,13 @@
     <!-- A reference to the entire .Net Framework and Windows SDK are automatically included -->
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="HarfBuzzSharp" Version="2.8.2.4" />
-    <PackageReference Include="SkiaSharp" Version="2.88.4" />
-    <PackageReference Include="SkiaSharp.Views" Version="2.88.4" />
-    <PackageReference Include="SkiaSharp.Views.Forms" Version="2.88.4" />
-    <PackageReference Include="Xamarin.Essentials" Version="1.6.1" />
-    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2401" />
-    <PackageReference Include="Topten.RichTextKit" Version="0.4.137" />
+    <PackageReference Include="HarfBuzzSharp" Version="2.8.2.5" />
+    <PackageReference Include="SkiaSharp" Version="2.88.5" />
+    <PackageReference Include="SkiaSharp.Views" Version="2.88.5" />
+    <PackageReference Include="SkiaSharp.Views.Forms" Version="2.88.5" />
+    <PackageReference Include="Xamarin.Essentials" Version="1.8.0" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2612" />
+    <PackageReference Include="Topten.RichTextKit" Version="0.4.166" />
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.14" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/Forms/SkiaSharpDemo.WPF/SkiaSharpDemo.WPF.csproj
+++ b/samples/Forms/SkiaSharpDemo.WPF/SkiaSharpDemo.WPF.csproj
@@ -11,13 +11,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HarfBuzzSharp" Version="2.8.2.4" />
-    <PackageReference Include="SkiaSharp" Version="2.88.4" />
-    <PackageReference Include="SkiaSharp.Views.WPF" Version="2.88.4" />
-    <PackageReference Include="SkiaSharp.Views.Forms.WPF" Version="2.88.4" />
-    <PackageReference Include="Xamarin.Essentials" Version="1.6.1" />
-    <PackageReference Include="Xamarin.Forms.Platform.WPF" Version="5.0.0.2401" />
-    <PackageReference Include="Topten.RichTextKit" Version="0.4.137" />
+    <PackageReference Include="HarfBuzzSharp" Version="2.8.2.5" />
+    <PackageReference Include="SkiaSharp" Version="2.88.5" />
+    <PackageReference Include="SkiaSharp.Views.WPF" Version="2.88.5" />
+    <PackageReference Include="SkiaSharp.Views.Forms.WPF" Version="2.88.5" />
+    <PackageReference Include="Xamarin.Essentials" Version="1.8.0" />
+    <PackageReference Include="Xamarin.Forms.Platform.WPF" Version="5.0.0.2612" />
+    <PackageReference Include="Topten.RichTextKit" Version="0.4.166" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Forms/SkiaSharpDemo.iOS/SkiaSharpDemo.iOS.csproj
+++ b/samples/Forms/SkiaSharpDemo.iOS/SkiaSharpDemo.iOS.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -69,13 +69,13 @@
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="HarfBuzzSharp" Version="2.8.2.4" />
-    <PackageReference Include="SkiaSharp" Version="2.88.4" />
-    <PackageReference Include="SkiaSharp.Views" Version="2.88.4" />
-    <PackageReference Include="SkiaSharp.Views.Forms" Version="2.88.4" />
-    <PackageReference Include="Xamarin.Essentials" Version="1.6.1" />
-    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2401" />
-    <PackageReference Include="Topten.RichTextKit" Version="0.4.137" />
+    <PackageReference Include="HarfBuzzSharp" Version="2.8.2.5" />
+    <PackageReference Include="SkiaSharp" Version="2.88.5" />
+    <PackageReference Include="SkiaSharp.Views" Version="2.88.5" />
+    <PackageReference Include="SkiaSharp.Views.Forms" Version="2.88.5" />
+    <PackageReference Include="Xamarin.Essentials" Version="1.8.0" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2612" />
+    <PackageReference Include="Topten.RichTextKit" Version="0.4.166" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\source\SkiaSharp.Extended.UI.Forms\SkiaSharp.Extended.UI.Forms.csproj">

--- a/samples/Forms/SkiaSharpDemo.macOS/SkiaSharpDemo.macOS.csproj
+++ b/samples/Forms/SkiaSharpDemo.macOS/SkiaSharpDemo.macOS.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -50,13 +50,13 @@
     <Reference Include="Xamarin.Mac" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="HarfBuzzSharp" Version="2.8.2.4" />
-    <PackageReference Include="SkiaSharp" Version="2.88.4" />
-    <PackageReference Include="SkiaSharp.Views" Version="2.88.4" />
-    <PackageReference Include="SkiaSharp.Views.Forms" Version="2.88.4" />
-    <PackageReference Include="Xamarin.Essentials" Version="1.6.1" />
-    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2401" />
-    <PackageReference Include="Topten.RichTextKit" Version="0.4.137" />
+    <PackageReference Include="HarfBuzzSharp" Version="2.8.2.5" />
+    <PackageReference Include="SkiaSharp" Version="2.88.5" />
+    <PackageReference Include="SkiaSharp.Views" Version="2.88.5" />
+    <PackageReference Include="SkiaSharp.Views.Forms" Version="2.88.5" />
+    <PackageReference Include="Xamarin.Essentials" Version="1.8.0" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2612" />
+    <PackageReference Include="Topten.RichTextKit" Version="0.4.166" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\source\SkiaSharp.Extended.UI.Forms\SkiaSharp.Extended.UI.Forms.csproj">

--- a/samples/Forms/SkiaSharpDemo/SkiaSharpDemo.csproj
+++ b/samples/Forms/SkiaSharpDemo/SkiaSharpDemo.csproj
@@ -7,14 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HarfBuzzSharp" Version="2.8.2.4" />
+    <PackageReference Include="HarfBuzzSharp" Version="2.8.2.5" />
     <PackageReference Include="NLipsum" Version="1.1.0" />
-    <PackageReference Include="SkiaSharp" Version="2.88.4" />
-    <PackageReference Include="SkiaSharp.Views.Forms" Version="2.88.4" />
+    <PackageReference Include="SkiaSharp" Version="2.88.5" />
+    <PackageReference Include="SkiaSharp.Views.Forms" Version="2.88.5" />
     <PackageReference Include="Svg.Skia" Version="1.0.0" />
-    <PackageReference Include="Topten.RichTextKit" Version="0.4.137" />
-    <PackageReference Include="Xamarin.Essentials" Version="1.6.1" />
-    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2401" />
+    <PackageReference Include="Topten.RichTextKit" Version="0.4.166" />
+    <PackageReference Include="Xamarin.Essentials" Version="1.8.0" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2612" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Maui/SkiaSharpDemo/SkiaSharpDemo.csproj
+++ b/samples/Maui/SkiaSharpDemo/SkiaSharpDemo.csproj
@@ -32,10 +32,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HarfBuzzSharp" Version="2.8.2.4" />
+    <PackageReference Include="HarfBuzzSharp" Version="2.8.2.5" />
     <PackageReference Include="NLipsum" Version="1.1.0" />
     <PackageReference Include="Svg.Skia" Version="1.0.0" />
-    <PackageReference Include="Topten.RichTextKit" Version="0.4.137" />
+    <PackageReference Include="Topten.RichTextKit" Version="0.4.166" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/SkiaSharp.Extended.UI.Forms.WPF/SkiaSharp.Extended.UI.Forms.WPF.csproj
+++ b/source/SkiaSharp.Extended.UI.Forms.WPF/SkiaSharp.Extended.UI.Forms.WPF.csproj
@@ -15,10 +15,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="2.88.4" />
-    <PackageReference Include="SkiaSharp.Skottie" Version="2.88.4" />
-    <PackageReference Include="SkiaSharp.Views.Forms.WPF" Version="2.88.4" />
-    <PackageReference Include="Xamarin.Forms.Platform.WPF" Version="5.0.0.2401" />
+    <PackageReference Include="SkiaSharp" Version="2.88.5" />
+    <PackageReference Include="SkiaSharp.Skottie" Version="2.88.5" />
+    <PackageReference Include="SkiaSharp.Views.Forms.WPF" Version="2.88.5" />
+    <PackageReference Include="Xamarin.Forms.Platform.WPF" Version="5.0.0.2612" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/SkiaSharp.Extended.UI.Forms/SkiaSharp.Extended.UI.Forms.csproj
+++ b/source/SkiaSharp.Extended.UI.Forms/SkiaSharp.Extended.UI.Forms.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
-    <TargetFrameworks Condition="$(IsMacOS) or $(IsWindows)">$(TargetFrameworks);MonoAndroid10.0;Xamarin.iOS10;Xamarin.Mac20;tizen40</TargetFrameworks>
+    <TargetFrameworks Condition="$(IsMacOS) or $(IsWindows)">$(TargetFrameworks);MonoAndroid13.0;Xamarin.iOS10;Xamarin.Mac20;tizen40</TargetFrameworks>
     <TargetFrameworks Condition="$(IsWindows)">$(TargetFrameworks);uap10.0.19041</TargetFrameworks>
     <AssemblyName>SkiaSharp.Extended.UI</AssemblyName>
     <RootNamespace>SkiaSharp.Extended.UI</RootNamespace>

--- a/source/SkiaSharp.Extended.UI.Forms/SkiaSharp.Extended.UI.Forms.csproj
+++ b/source/SkiaSharp.Extended.UI.Forms/SkiaSharp.Extended.UI.Forms.csproj
@@ -17,10 +17,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="2.88.4" />
-    <PackageReference Include="SkiaSharp.Skottie" Version="2.88.4" />
-    <PackageReference Include="SkiaSharp.Views.Forms" Version="2.88.4" />
-    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2401" />
+    <PackageReference Include="SkiaSharp" Version="2.88.5" />
+    <PackageReference Include="SkiaSharp.Skottie" Version="2.88.5" />
+    <PackageReference Include="SkiaSharp.Views.Forms" Version="2.88.5" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2612" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/SkiaSharp.Extended.UI.Maui/SkiaSharp.Extended.UI.Maui.csproj
+++ b/source/SkiaSharp.Extended.UI.Maui/SkiaSharp.Extended.UI.Maui.csproj
@@ -29,9 +29,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="2.88.4" />
-    <PackageReference Include="SkiaSharp.Skottie" Version="2.88.4" />
-    <PackageReference Include="SkiaSharp.Views.Maui.Controls" Version="2.88.4" />
+    <PackageReference Include="SkiaSharp" Version="2.88.5" />
+    <PackageReference Include="SkiaSharp.Skottie" Version="2.88.5" />
+    <PackageReference Include="SkiaSharp.Views.Maui.Controls" Version="2.88.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/SkiaSharp.Extended/SkiaSharp.Extended.csproj
+++ b/source/SkiaSharp.Extended/SkiaSharp.Extended.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="2.88.4" />
+    <PackageReference Include="SkiaSharp" Version="2.88.5" />
   </ItemGroup>
 
 </Project>

--- a/tests/SkiaSharp.Extended.Tests/SkiaSharp.Extended.Tests.csproj
+++ b/tests/SkiaSharp.Extended.Tests/SkiaSharp.Extended.Tests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="2.88.4" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.4" />
+    <PackageReference Include="SkiaSharp" Version="2.88.5" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />

--- a/tests/SkiaSharp.Extended.UI.Forms.Tests/SkiaSharp.Extended.UI.Forms.Tests.csproj
+++ b/tests/SkiaSharp.Extended.UI.Forms.Tests/SkiaSharp.Extended.UI.Forms.Tests.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="2.88.4" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.4" />
+    <PackageReference Include="SkiaSharp" Version="2.88.5" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />

--- a/tests/SkiaSharp.Extended.UI.Forms.WPF.Tests/SkiaSharp.Extended.UI.Forms.WPF.Tests.csproj
+++ b/tests/SkiaSharp.Extended.UI.Forms.WPF.Tests/SkiaSharp.Extended.UI.Forms.WPF.Tests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="2.88.4" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.4" />
+    <PackageReference Include="SkiaSharp" Version="2.88.5" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />

--- a/tests/SkiaSharp.Extended.UI.Maui.Tests/SkiaSharp.Extended.UI.Maui.Tests.csproj
+++ b/tests/SkiaSharp.Extended.UI.Maui.Tests/SkiaSharp.Extended.UI.Maui.Tests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="2.88.4" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.4" />
+    <PackageReference Include="SkiaSharp" Version="2.88.5" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />


### PR DESCRIPTION
- Depended Packages Updated 
- Sample Android Project Target Version switch to 13. Because Xamarin.Essential needs that.