### PR TITLE
Add AnimationFinished event to SKLottieView

### DIFF
--- a/docs/api/ui-forms/sklottieview.md
+++ b/docs/api/ui-forms/sklottieview.md
@@ -24,10 +24,11 @@ There are several properties that can be used to control th animation playback:
 
 There are a few events that can be used to be notified of animation loading events:
 
-| Event                | Type            | Description |
-| :------------------- | :-------------- | :---------- |
-| **AnimationLoaded**  | `EventHandler`  | Invoked when the animation has loaded successfully. |
-| **AnimationFailed**  | `EventHandler`  | Invoked when there was an error loading the animation. |
+| Event                   | Type            | Description |
+| :---------------------- | :-------------- | :---------- |
+| **AnimationLoaded**     | `EventHandler`  | Invoked when the animation has loaded successfully. |
+| **AnimationFailed**     | `EventHandler`  | Invoked when there was an error loading the animation. |
+| **AnimationCompleted**  | `EventHandler`  | Invoked when the animation is finished playing (after all the repeats). Infinite animations never complete so will not trigger the event. |
 
 ## Parts
 

--- a/docs/api/ui-maui/sklottieview.md
+++ b/docs/api/ui-maui/sklottieview.md
@@ -24,10 +24,11 @@ There are several properties that can be used to control th animation playback:
 
 There are a few events that can be used to be notified of animation loading events:
 
-| Event                | Type            | Description |
-| :------------------- | :-------------- | :---------- |
-| **AnimationLoaded**  | `EventHandler`  | Invoked when the animation has loaded successfully. |
-| **AnimationFailed**  | `EventHandler`  | Invoked when there was an error loading the animation. |
+| Event                   | Type            | Description |
+| :---------------------- | :-------------- | :---------- |
+| **AnimationLoaded**     | `EventHandler`  | Invoked when the animation has loaded successfully. |
+| **AnimationFailed**     | `EventHandler`  | Invoked when there was an error loading the animation. |
+| **AnimationCompleted**  | `EventHandler`  | Invoked when the animation is finished playing (after all the repeats). Infinite animations never complete so will not trigger the event. |
 
 ## Parts
 

--- a/samples/Maui/SkiaSharpDemo/Demos/Lottie/LottiePage.xaml
+++ b/samples/Maui/SkiaSharpDemo/Demos/Lottie/LottiePage.xaml
@@ -13,7 +13,8 @@
                                Progress="{Binding Progress}"
                                IsAnimationEnabled="{Binding IsBusy}"
                                AnimationFailed="OnAnimationFailed"
-                               AnimationLoaded="OnAnimationLoaded" />
+                               AnimationLoaded="OnAnimationLoaded"
+                               AnimationCompleted="OnAnimationCompleted" />
 
         <BoxView Color="Green" Opacity="0.5" CornerRadius="12"
                  WidthRequest="25" HeightRequest="24" Margin="24"

--- a/samples/Maui/SkiaSharpDemo/Demos/Lottie/LottiePage.xaml.cs
+++ b/samples/Maui/SkiaSharpDemo/Demos/Lottie/LottiePage.xaml.cs
@@ -71,4 +71,9 @@ public partial class LottiePage : ContentPage
 	{
 		Debug.WriteLine("Lottie animation loaded.");
 	}
+
+	private void OnAnimationCompleted(object sender, EventArgs e)
+	{
+		Debug.WriteLine("Lottie animation finished playing.");
+	}
 }

--- a/source/SkiaSharp.Extended.UI/Controls/Lottie/SKLottieView.shared.cs
+++ b/source/SkiaSharp.Extended.UI/Controls/Lottie/SKLottieView.shared.cs
@@ -57,6 +57,12 @@ public class SKLottieView : SKAnimatedSurfaceView
 		ResourceLoader<Themes.SKLottieViewResources>.EnsureRegistered(this);
 
 		IsAnimationEnabled = true;
+
+#if DEBUG
+		AnimationCompleted += (s, e) => DebugUtils.LogEvent(nameof(AnimationCompleted));
+		AnimationFailed += (s, e) => DebugUtils.LogEvent(nameof(AnimationFailed));
+		AnimationLoaded += (s, e) => DebugUtils.LogEvent(nameof(AnimationLoaded));
+#endif
 	}
 
 	public SKLottieImageSource? Source
@@ -98,6 +104,8 @@ public class SKLottieView : SKAnimatedSurfaceView
 	public event EventHandler? AnimationFailed;
 
 	public event EventHandler? AnimationLoaded;
+
+	public event EventHandler? AnimationCompleted;
 
 	protected override void Update(TimeSpan deltaTime)
 	{
@@ -191,6 +199,9 @@ public class SKLottieView : SKAnimatedSurfaceView
 			IsComplete =
 				isFinishedRun &&
 				repeatsCompleted >= totalRepeatCount;
+
+			if (IsComplete)
+				AnimationCompleted?.Invoke(this, EventArgs.Empty);
 		}
 
 		if (!IsAnimationEnabled)

--- a/source/SkiaSharp.Extended.UI/Utils/DebugUtils.shared.cs
+++ b/source/SkiaSharp.Extended.UI/Utils/DebugUtils.shared.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using System.Diagnostics;
+using System.Linq;
 
 namespace SkiaSharp.Extended.UI;
 

--- a/source/SkiaSharp.Extended.UI/Utils/DebugUtils.shared.cs
+++ b/source/SkiaSharp.Extended.UI/Utils/DebugUtils.shared.cs
@@ -17,4 +17,16 @@ internal static class DebugUtils
 			Debug.WriteLine($"PropertyChanged: {sender.GetType().Name}.{e.PropertyName} = {value}");
 		}
 	}
+
+	[Conditional("DEBUG")]
+	public static void LogMessage(string message, params object[] args)
+	{
+		Debug.WriteLine($"{message} [{string.Join(", ", args.Select(a => a?.ToString()))}]");
+	}
+
+	[Conditional("DEBUG")]
+	public static void LogEvent(string eventName, params object[] args)
+	{
+		Debug.WriteLine($"Event: {eventName}({string.Join(", ", args.Select(a => a?.ToString()))})");
+	}
 }

--- a/tests/SkiaSharp.Extended.UI.Tests/Controls/Lottie/SKLottieViewTest.cs
+++ b/tests/SkiaSharp.Extended.UI.Tests/Controls/Lottie/SKLottieViewTest.cs
@@ -46,6 +46,8 @@ public class SKLottieViewTest
 		// create
 		var source = new SKFileLottieImageSource { File = TrophyJson };
 		var lottie = new WaitingLottieView { Source = source };
+		var animationCompleted = 0;
+		lottie.AnimationCompleted += (s, e) => animationCompleted++;
 		await lottie.LoadedTask;
 
 		// update
@@ -54,6 +56,7 @@ public class SKLottieViewTest
 		// test
 		Assert.Equal(TimeSpan.FromSeconds(1), lottie.Progress);
 		Assert.False(lottie.IsComplete);
+		Assert.Equal(0, animationCompleted);
 	}
 
 	[Fact]
@@ -62,22 +65,27 @@ public class SKLottieViewTest
 		// create
 		var source = new SKFileLottieImageSource { File = TrophyJson };
 		var lottie = new WaitingLottieView { Source = source };
+		var animationCompleted = 0;
+		lottie.AnimationCompleted += (s, e) => animationCompleted++;
 		await lottie.LoadedTask;
 
 		// update & test
 		lottie.CallUpdate(TimeSpan.FromSeconds(1));
 		Assert.Equal(TimeSpan.FromSeconds(1), lottie.Progress);
 		Assert.False(lottie.IsComplete);
+		Assert.Equal(0, animationCompleted);
 
 		// update & test
 		lottie.CallUpdate(TimeSpan.FromSeconds(1));
 		Assert.Equal(TimeSpan.FromSeconds(2), lottie.Progress);
 		Assert.False(lottie.IsComplete);
+		Assert.Equal(0, animationCompleted);
 
 		// update & test
 		lottie.CallUpdate(TimeSpan.FromSeconds(1));
 		Assert.Equal(TimeSpan.FromSeconds(2.3666665), lottie.Progress);
 		Assert.True(lottie.IsComplete);
+		Assert.Equal(1, animationCompleted);
 	}
 
 	[Fact]
@@ -86,6 +94,8 @@ public class SKLottieViewTest
 		// create
 		var source = new SKFileLottieImageSource { File = TrophyJson };
 		var lottie = new WaitingLottieView { Source = source };
+		var animationCompleted = 0;
+		lottie.AnimationCompleted += (s, e) => animationCompleted++;
 		await lottie.LoadedTask;
 
 		// update
@@ -94,6 +104,7 @@ public class SKLottieViewTest
 		// test
 		Assert.Equal(TimeSpan.FromSeconds(2.3666665), lottie.Progress);
 		Assert.True(lottie.IsComplete);
+		Assert.Equal(1, animationCompleted);
 	}
 
 	[Fact]
@@ -102,6 +113,8 @@ public class SKLottieViewTest
 		// create
 		var source = new SKFileLottieImageSource { File = TrophyJson };
 		var lottie = new WaitingLottieView { Source = source };
+		var animationCompleted = 0;
+		lottie.AnimationCompleted += (s, e) => animationCompleted++;
 		await lottie.LoadedTask;
 
 		// update
@@ -110,6 +123,7 @@ public class SKLottieViewTest
 		// test
 		Assert.Equal(TimeSpan.Zero, lottie.Progress);
 		Assert.False(lottie.IsComplete);
+		Assert.Equal(0, animationCompleted);
 	}
 
 	[Fact]
@@ -118,6 +132,8 @@ public class SKLottieViewTest
 		// create
 		var source = new SKFileLottieImageSource { File = TrophyJson };
 		var lottie = new WaitingLottieView { Source = source };
+		var animationCompleted = 0;
+		lottie.AnimationCompleted += (s, e) => animationCompleted++;
 		await lottie.LoadedTask;
 
 		// update
@@ -128,6 +144,7 @@ public class SKLottieViewTest
 		// test
 		Assert.Equal(TimeSpan.FromSeconds(1), lottie.Progress);
 		Assert.False(lottie.IsComplete);
+		Assert.Equal(0, animationCompleted);
 	}
 
 	[Theory]
@@ -150,6 +167,8 @@ public class SKLottieViewTest
 		// create
 		var source = new SKFileLottieImageSource { File = TrophyJson };
 		var lottie = new WaitingLottieView { Source = source, RepeatMode = repeatMode, RepeatCount = -1 };
+		var animationCompleted = 0;
+		lottie.AnimationCompleted += (s, e) => animationCompleted++;
 		await lottie.LoadedTask;
 
 		// update
@@ -159,6 +178,7 @@ public class SKLottieViewTest
 		// test
 		Assert.Equal(TimeSpan.FromSeconds(progress), lottie.Progress);
 		Assert.False(lottie.IsComplete);
+		Assert.Equal(0, animationCompleted);
 	}
 
 	[Theory]
@@ -180,6 +200,8 @@ public class SKLottieViewTest
 		// create
 		var source = new SKFileLottieImageSource { File = TrophyJson };
 		var lottie = new WaitingLottieView { Source = source, RepeatMode = repeatMode, RepeatCount = 0 };
+		var animationCompleted = 0;
+		lottie.AnimationCompleted += (s, e) => animationCompleted++;
 		await lottie.LoadedTask;
 
 		// update
@@ -189,5 +211,9 @@ public class SKLottieViewTest
 		// test
 		Assert.Equal(TimeSpan.FromSeconds(progress), lottie.Progress);
 		Assert.Equal(isComplete, lottie.IsComplete);
+		if (isComplete)
+			Assert.Equal(1, animationCompleted);
+		else
+			Assert.Equal(0, animationCompleted);
 	}
 }


### PR DESCRIPTION
**Description of Change**

This PR adds an `AnimationCompleted` event to `SKLottieView` to indicate when the animation is no longer playing.

This event fires after the `IsComplete` is set to `true` and thus means that it only fires after all the repeats are finished. So an infinite repeating animation will never be complete nor will the event fire. But for a X repeat (including 0 repeats) animation, the event will fire after all the repeats have happened.

**Bugs Fixed**

- Fixes #161

**API Changes**

Added:

```cs
class SKLottieView {
    event EventHandler AnimationCompleted;
}
```


**Behavioral Changes**

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**PR Checklist**

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation
