### PR TITLE
Avoid memory leaks in the timers

### DIFF
--- a/source/SkiaSharp.Extended.UI/Controls/SKAnimatedSurfaceView.shared.cs
+++ b/source/SkiaSharp.Extended.UI/Controls/SKAnimatedSurfaceView.shared.cs
@@ -12,7 +12,7 @@ public class SKAnimatedSurfaceView : SKSurfaceView
 
 	private readonly SKFrameCounter frameCounter = new SKFrameCounter();
 
-	internal SKAnimatedSurfaceView()
+	public SKAnimatedSurfaceView()
 	{
 		Loaded += OnLoaded;
 	}
@@ -73,13 +73,18 @@ public class SKAnimatedSurfaceView : SKSurfaceView
 		if (!IsAnimationEnabled)
 			return;
 
+		var weakThis = new WeakReference<SKAnimatedSurfaceView>(this);
+
 		Dispatcher.StartTimer(
 			TimeSpan.FromMilliseconds(16),
 			() =>
 			{
-				Invalidate();
+				if (!weakThis.TryGetTarget(out var strongThis))
+					return false;
 
-				return IsAnimationEnabled;
+				strongThis.Invalidate();
+
+				return strongThis.IsAnimationEnabled;
 			});
 	}
 }

--- a/tests/SkiaSharp.Extended.UI.Maui.Tests/Controls/DispatchingBaseTest.cs
+++ b/tests/SkiaSharp.Extended.UI.Maui.Tests/Controls/DispatchingBaseTest.cs
@@ -9,8 +9,11 @@ public class DispatchingBaseTest : IDisposable
 		DispatcherProvider.SetCurrent(dipatcherProvider = new MockDispatcherProvider());
 	}
 
-	public void Dispose() =>
+	public void Dispose()
+	{
+		DispatcherProvider.SetCurrent(null);
 		dipatcherProvider.Dispose();
+	}
 
 	private class MockDispatcherProvider : IDispatcherProvider, IDisposable
 	{

--- a/tests/SkiaSharp.Extended.UI.Maui.Tests/Controls/DispatchingBaseTest.cs
+++ b/tests/SkiaSharp.Extended.UI.Maui.Tests/Controls/DispatchingBaseTest.cs
@@ -1,0 +1,84 @@
+﻿namespace SkiaSharp.Extended.UI.Controls.Tests;
+
+public class DispatchingBaseTest : IDisposable
+{
+	private readonly MockDispatcherProvider dipatcherProvider;
+
+	public DispatchingBaseTest()
+	{
+		DispatcherProvider.SetCurrent(dipatcherProvider = new MockDispatcherProvider());
+	}
+
+	public void Dispose() =>
+		dipatcherProvider.Dispose();
+
+	private class MockDispatcherProvider : IDispatcherProvider, IDisposable
+	{
+		private readonly ThreadLocal<IDispatcher?> dispatcherInstance = new(() => new MockDispatcher());
+
+		public void Dispose() =>
+			dispatcherInstance.Dispose();
+
+		public IDispatcher? GetForCurrentThread() =>
+			dispatcherInstance.Value;
+	}
+
+	private class MockDispatcher : IDispatcher
+	{
+		public bool IsDispatchRequired => false;
+
+		public bool Dispatch(Action action)
+		{
+			action();
+			return true;
+		}
+
+		public bool DispatchDelayed(TimeSpan delay, Action action)
+		{
+			this.StartTimer(delay, () =>
+			{
+				action();
+				return false;
+			});
+			return true;
+		}
+
+		public IDispatcherTimer CreateTimer() =>
+			new MockDispatcherTimer(this);
+	}
+
+	private class MockDispatcherTimer : IDispatcherTimer
+	{
+		private readonly MockDispatcher dispatcher;
+		private Timer? timer;
+
+		public MockDispatcherTimer(MockDispatcher dispatcher)
+		{
+			this.dispatcher = dispatcher;
+		}
+
+		public TimeSpan Interval { get; set; }
+
+		public bool IsRepeating { get; set; }
+
+		public bool IsRunning => timer != null;
+
+		public event EventHandler? Tick;
+
+		public void Start()
+		{
+			timer = new Timer(OnTimeout, null, Interval, IsRepeating ? Interval : Timeout.InfiniteTimeSpan);
+
+			void OnTimeout(object? state)
+			{
+				dispatcher.Dispatch(() => Tick?.Invoke(this, EventArgs.Empty));
+			}
+		}
+
+		public void Stop()
+		{
+			timer?.Dispose();
+			timer = null;
+		}
+	}
+}

--- a/tests/SkiaSharp.Extended.UI.Maui.Tests/Controls/SKAnimatedSurfaceViewTest.cs
+++ b/tests/SkiaSharp.Extended.UI.Maui.Tests/Controls/SKAnimatedSurfaceViewTest.cs
@@ -1,0 +1,40 @@
+﻿using Xunit;
+
+namespace SkiaSharp.Extended.UI.Controls.Tests;
+
+public class SKAnimatedSurfaceViewTest : DispatchingBaseTest
+{
+	[Theory]
+	[InlineData(true)]
+	[InlineData(false)]
+	public async Task DoesNotLeak(bool animate)
+	{
+		var weak = Setup(animate);
+
+		await Task.Yield();
+
+		GC.Collect();
+		GC.WaitForPendingFinalizers();
+
+		Assert.False(weak.IsAlive);
+
+		static WeakReference Setup(bool animate)
+		{
+			var view = new SKAnimatedSurfaceView();
+			var window = new Window
+			{
+				Page = new ContentPage
+				{
+					Content = view
+				}
+			};
+
+			if (animate)
+			{
+				view.IsAnimationEnabled = true;
+			}
+
+			return new WeakReference(view);
+		}
+	}
+}


### PR DESCRIPTION
**Description of Change**

Fix the memory leak in the animated view. The timer was capturing the view and the entire hierarchy in a static timer. 

**Bugs Fixed**

<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

- Fixes #250 

**API Changes**

<!-- REPLACE THIS COMMENT
List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName => object Cell.NewPropertyName`
 
-->

**Behavioral Changes**

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

**PR Checklist**

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation
