### PR TITLE
Fix merge dictionary 

### DIFF
--- a/source/SkiaSharp.Extended.UI.Maui/Utils/ResourceLoader.shared.cs
+++ b/source/SkiaSharp.Extended.UI.Maui/Utils/ResourceLoader.shared.cs
@@ -3,12 +3,9 @@
 internal static class ResourceLoader<T>
 	where T : ResourceDictionary, new()
 {
-	private static bool registered;
-
 	internal static void EnsureRegistered(VisualElement? element = null)
 	{
-		if (registered)
-			return;
+		bool registered = false;
 
 		// try register with the current app
 		var merged = Application.Current?.Resources?.MergedDictionaries;


### PR DESCRIPTION
**Description of Change**
The current code doesn't take into account ResourcesDictionaries can change. f.e. in my use case we merge dictionaries when the user switches themes. _(based on this doc - https://learn.microsoft.com/th-th/previous-versions/xamarin/xamarin-forms/user-interface/theming/theming)_

**Bugs Fixed**

Fixed #284 

**API Changes**
Removed the static registered bool, so it re-checks when needed

I also needed to update it to .net 8, as it wouldn't let me build with the following error - 
```
The workload 'net7.0-android' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/maui-support-policy for more information about the support policy.
```

**Behavioral Changes**
None

**PR Checklist**

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
