### PR TITLE
Update packages for Android 16

### DIFF
--- a/samples/SkiaSharpDemo/SkiaSharpDemo.csproj
+++ b/samples/SkiaSharpDemo/SkiaSharpDemo.csproj
@@ -13,7 +13,7 @@
     <Nullable>enable</Nullable>
 
     <!-- Display name -->
-    <ApplicationTitle>EkiaSharp Ex.</ApplicationTitle>
+    <ApplicationTitle>SkiaSharp Ex.</ApplicationTitle>
 
     <!-- App Identifier -->
     <ApplicationId>com.companyname.skiasharpdemo</ApplicationId>
@@ -31,9 +31,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HarfBuzzSharp" Version="8.3.0" />
+    <PackageReference Include="HarfBuzzSharp" Version="8.3.0.1" />
     <PackageReference Include="NLipsum" Version="1.1.0" />
-    <PackageReference Include="Svg.Skia" Version="2.0.0.2" />
+    <PackageReference Include="Svg.Skia" Version="2.0.0.4" />
     <PackageReference Include="Topten.RichTextKit" Version="0.4.166" />
     <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
   </ItemGroup>

--- a/source/SkiaSharp.Extended.UI.Maui/SkiaSharp.Extended.UI.Maui.csproj
+++ b/source/SkiaSharp.Extended.UI.Maui/SkiaSharp.Extended.UI.Maui.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0</TargetFrameworks>
     <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
-    <!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
+    <!-- <TargetFrameworks>$(TargetFrameworks);net9.0-tizen</TargetFrameworks> -->
     <UseMaui>true</UseMaui>
     <SingleProject>true</SingleProject>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -29,10 +29,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="3.116.0" />
-    <PackageReference Include="SkiaSharp.Skottie" Version="3.116.0" />
-    <PackageReference Include="SkiaSharp.Views.Maui.Controls" Version="3.116.0" />
+    <PackageReference Include="SkiaSharp" Version="3.116.1" />
+    <PackageReference Include="SkiaSharp.Skottie" Version="3.116.1" />
+    <PackageReference Include="SkiaSharp.Views.Maui.Controls" Version="3.116.1" />
     <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/SkiaSharp.Extended/SkiaSharp.Extended.csproj
+++ b/source/SkiaSharp.Extended/SkiaSharp.Extended.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net9.0</TargetFrameworks>
     <AssemblyName>SkiaSharp.Extended</AssemblyName>
     <RootNamespace>SkiaSharp.Extended</RootNamespace>
   </PropertyGroup>
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="3.116.0" />
+    <PackageReference Include="SkiaSharp" Version="3.116.1" />
   </ItemGroup>
 
 </Project>

--- a/tests/SkiaSharp.Extended.Tests/SkiaSharp.Extended.Tests.csproj
+++ b/tests/SkiaSharp.Extended.Tests/SkiaSharp.Extended.Tests.csproj
@@ -1,19 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="3.116.0" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.116.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0-pre.35">
+    <PackageReference Include="SkiaSharp" Version="3.116.1" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.116.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/SkiaSharp.Extended.Tests/SkiaSharp.Extended.Tests.csproj
+++ b/tests/SkiaSharp.Extended.Tests/SkiaSharp.Extended.Tests.csproj
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="6.0.4"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/SkiaSharp.Extended.UI.Maui.Tests/SkiaSharp.Extended.UI.Maui.Tests.csproj
+++ b/tests/SkiaSharp.Extended.UI.Maui.Tests/SkiaSharp.Extended.UI.Maui.Tests.csproj
@@ -15,7 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="6.0.4"/>
     <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
   </ItemGroup>
 

--- a/tests/SkiaSharp.Extended.UI.Maui.Tests/SkiaSharp.Extended.UI.Maui.Tests.csproj
+++ b/tests/SkiaSharp.Extended.UI.Maui.Tests/SkiaSharp.Extended.UI.Maui.Tests.csproj
@@ -1,21 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseMaui>true</UseMaui>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="3.116.0" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.116.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0-pre.35">
+    <PackageReference Include="SkiaSharp" Version="3.116.1" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.116.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
     <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
**Description of Change**

With the upcoming requirements for Andoird 16 KB page sizes, we need to update to the latest stable SkiaSharp version. I didn't see any problems to fully switch to .net9 for the demo project.

**Bugs Fixed**

https://github.com/mono/SkiaSharp.Extended/issues/308

**API Changes**

None

**Behavioral Changes**

None

**PR Checklist**

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation
