### PR TITLE
Update to SkiaSharp 3.119.1 (stable)

### DIFF
--- a/source/SkiaSharp.Extended.UI.Maui/SkiaSharp.Extended.UI.Maui.csproj
+++ b/source/SkiaSharp.Extended.UI.Maui/SkiaSharp.Extended.UI.Maui.csproj
@@ -28,9 +28,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="3.119.1-preview.1" />
-    <PackageReference Include="SkiaSharp.Skottie" Version="3.119.1-preview.1" />
-    <PackageReference Include="SkiaSharp.Views.Maui.Controls" Version="3.119.1-preview.1" />
+    <PackageReference Include="SkiaSharp" Version="3.119.1" />
+    <PackageReference Include="SkiaSharp.Skottie" Version="3.119.1" />
+    <PackageReference Include="SkiaSharp.Views.Maui.Controls" Version="3.119.1" />
     <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
     <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
   </ItemGroup>

--- a/source/SkiaSharp.Extended/SkiaSharp.Extended.csproj
+++ b/source/SkiaSharp.Extended/SkiaSharp.Extended.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="3.119.1-preview.1" />
+    <PackageReference Include="SkiaSharp" Version="3.119.1" />
   </ItemGroup>
 
 </Project>

--- a/tests/SkiaSharp.Extended.Tests/SkiaSharp.Extended.Tests.csproj
+++ b/tests/SkiaSharp.Extended.Tests/SkiaSharp.Extended.Tests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="3.119.1-preview.1" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.1-preview.1" />
+    <PackageReference Include="SkiaSharp" Version="3.119.1" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/SkiaSharp.Extended.UI.Maui.Tests/SkiaSharp.Extended.UI.Maui.Tests.csproj
+++ b/tests/SkiaSharp.Extended.UI.Maui.Tests/SkiaSharp.Extended.UI.Maui.Tests.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="3.119.1-preview.1" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.1-preview.1" />
+    <PackageReference Include="SkiaSharp" Version="3.119.1" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Update the SkiaSharp dependencies to a stable version for the next release.