### PR TITLE
fix: add nuget.org source for MAUI workload installation

### DIFF
--- a/.github/workflows/builds-docs.yml
+++ b/.github/workflows/builds-docs.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Install MAUI workload
-      run: dotnet workload install maui
+      run: dotnet workload install maui --source https://api.nuget.org/v3/index.json
 
     - name: Restore .NET tools
       run: dotnet tool restore


### PR DESCRIPTION
## Problem

The docs CI workflow was failing because `dotnet workload install maui` couldn't find workload packages in the configured NuGet feeds.

Error:
```
Version 26.2.10191 of package microsoft.ios.runtime.ios-arm64.net10.0_26.2 is not found in NuGet feeds
```

## Solution

Explicitly add the nuget.org source when installing workloads:

```yaml
dotnet workload install maui --source https://api.nuget.org/v3/index.json
```

## Note

I apologize for merging PR #335 with the failing CI - that was a mistake on my part. This PR fixes the underlying issue.