### PR TITLE
fix: install MAUI workload in Azure Pipeline

### DIFF
--- a/scripts/azure-pipelines-steps-prepare.yml
+++ b/scripts/azure-pipelines-steps-prepare.yml
@@ -29,5 +29,8 @@ steps:
       Write-Host "##vso[task.setvariable variable=JavaSdkDirectory]$env:JAVA_HOME"
     displayName: Set Java SDK Directory
 
+  - pwsh: dotnet workload install maui --source https://api.nuget.org/v3/index.json
+    displayName: Install MAUI workload
+
   - pwsh: dotnet tool restore
     displayName: Restore the dotnet tools


### PR DESCRIPTION
## Problem

The Azure Pipeline CI was failing with:
```
NETSDK1147: To build this project, the following workloads must be installed: android
```

## Solution

Added `dotnet workload install maui --source https://api.nuget.org/v3/index.json` to the prepare steps.

This is the same fix we applied to the GitHub Actions docs workflow.