### PR TITLE
Add InventoryAsCode metadata

### DIFF
--- a/es-metadata.yml
+++ b/es-metadata.yml
@@ -1,0 +1,12 @@
+schemaVersion: 1.0.0
+providers:
+- provider: InventoryAsCode
+  version: 1.0.0
+  metadata:
+    isProduction: true
+    accountableOwners:
+      service: 9d770e15-6208-4284-b347-b2762803623b
+    routing:
+      defaultAreaPath:
+        org: devdiv
+        path: DevDiv\.NET MAUI


### PR DESCRIPTION
**Description of Change**

Adds `es-metadata.yml` at the repository root to configure InventoryAsCode:

- Marks the repository as production.
- Assigns service `9d770e15-6208-4284-b347-b2762803623b` as the accountable owner.
- Sets `DevDiv\.NET MAUI` as the default area path in the `devdiv` organization.

**Bugs Fixed**

None.

**API Changes**

None.

**Behavioral Changes**

None. This change only adds repository inventory and routing metadata.

**PR Checklist**

- [x] Has tests (not applicable for declarative metadata)
- [x] Has samples (not applicable)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation (not applicable)